### PR TITLE
Fix legal move edge cases and add regression coverage

### DIFF
--- a/internal/bitsboard-move-generator.go
+++ b/internal/bitsboard-move-generator.go
@@ -269,17 +269,17 @@ func (g *BitsBoardMoveGenerator) PawnPseudoLegalMoves(pos *Position, idx int8) (
 			if (isWhite && targetIdx >= A8) || (!isWhite && targetIdx <= H1) {
 				// Handle promotion
 				promotionIdx = targetIdx
-			} else {
-				if isWhite && targetIdx >= A4 && targetIdx <= H4 && targetIdx-idx == 16 && pos.occupied&(1<<(idx+8)) != 0 {
-					continue
-				}
-
-				if !isWhite && targetIdx >= A5 && targetIdx <= H5 && idx-targetIdx == 16 && pos.occupied&(1<<(idx-8)) != 0 {
-					continue
-				}
-
-				moves = append(moves, targetIdx)
 			}
+
+			if isWhite && targetIdx >= A4 && targetIdx <= H4 && targetIdx-idx == 16 && pos.occupied&(1<<(idx+8)) != 0 {
+				continue
+			}
+
+			if !isWhite && targetIdx >= A5 && targetIdx <= H5 && idx-targetIdx == 16 && pos.occupied&(1<<(idx-8)) != 0 {
+				continue
+			}
+
+			moves = append(moves, targetIdx)
 		}
 	}
 
@@ -303,9 +303,9 @@ func (g *BitsBoardMoveGenerator) PawnPseudoLegalMoves(pos *Position, idx int8) (
 			if (isWhite && targetIdx >= A8) || (!isWhite && targetIdx <= H1) {
 				// Handle promotion with capture
 				promotionIdx = targetIdx
-			} else {
-				moves = append(moves, targetIdx)
 			}
+
+			moves = append(moves, targetIdx)
 		}
 	}
 

--- a/internal/bitsboard-move-generator_test.go
+++ b/internal/bitsboard-move-generator_test.go
@@ -282,6 +282,16 @@ func TestPawnPseudoLegalMoves(t *testing.T) {
 			piecePos:  C5,
 			moves:     []int8{C6, D6},
 		},
+		"single push promotion target": {
+			fenString: "7k/3P4/8/8/8/8/8/4K3 w - - 0 1",
+			piecePos:  D7,
+			moves:     []int8{D8},
+		},
+		"capture promotion targets": {
+			fenString: "2r1k3/3P4/8/8/8/8/8/4K3 w - - 0 1",
+			piecePos:  D7,
+			moves:     []int8{C8, D8, E8},
+		},
 	}
 
 	generator := NewBitsBoardMoveGenerator()
@@ -293,8 +303,22 @@ func TestPawnPseudoLegalMoves(t *testing.T) {
 				t.Fatal(err.Error())
 			}
 
-			moves, _ := generator.PawnPseudoLegalMoves(pos, d.piecePos)
+			moves, promotionIdx := generator.PawnPseudoLegalMoves(pos, d.piecePos)
 			assert.ElementsMatch(t, d.moves, moves, "Moves do not match")
+
+			hasPromotionMove := false
+			for _, move := range d.moves {
+				if isPromotionSquare(pos.activeColor, move) {
+					hasPromotionMove = true
+					break
+				}
+			}
+
+			if hasPromotionMove {
+				assert.True(t, isPromotionSquare(pos.activeColor, promotionIdx))
+			} else {
+				assert.Equal(t, int8(-1), promotionIdx)
+			}
 		})
 	}
 }

--- a/internal/check.go
+++ b/internal/check.go
@@ -69,114 +69,50 @@ func isSquareAttackedBySlidingPiece(pos *Position, squareIdx int8, kingColor int
 	return false
 }
 
-func calculateActualAttacks(pos *Position, idx int8, dir int) uint64 {
-	attackMask := diagonalAttacksMask[idx][dir]
-	blocker := attackMask & pos.occupied
+func scanRayForAttack(pos *Position, startIdx int8, direction int8, enemyColor int8, targets uint64) bool {
+	for step := int8(1); step < 8; step++ {
+		nextIdx := startIdx + step*direction
+		if nextIdx < 0 || nextIdx >= 64 || !isSameLineOrRow(startIdx, nextIdx, direction) {
+			return false
+		}
 
-	lsb, msb := leastSignificantOne(blocker), mostSignificantBit(blocker)
-	if msb == lsb || blocker == 0 {
-		return attackMask
+		piece := pos.PieceAt(nextIdx)
+		if piece == NoPiece {
+			continue
+		}
+
+		if piece.Color() != enemyColor {
+			return false
+		}
+
+		return (targets & (uint64(1) << nextIdx)) != 0
 	}
 
-	switch dir {
-	case 0: //SouthWest
-		return attackMask & ^((1 << (msb + 1)) - 1)
-	case 1: //SouthEast
-		return attackMask & ^((1 << (lsb + 1)) - 1)
-	case 2: //NorthWest
-		return attackMask&(1<<msb) - 1
-	case 3: //NorthEast
-		return attackMask&(1<<lsb) - 1
-	}
-
-	panic("Unexpected direction value")
+	return false
 }
 
 // isDiagonallyAttacked determines if the position at index is diagonally attacked by the enemy.
 func isDiagonallyAttacked(pos *Position, idx int8, enemyColor int8) bool {
-	enemyDiagonalSliders := pos.OccupancyMask(enemyColor) & (pos.queenBoard | pos.bishopBoard)
+	targets := (pos.queenBoard | pos.bishopBoard) & pos.OccupancyMask(enemyColor)
 
-	if enemyDiagonalSliders&diagonalCombinedAttacksMask[idx] == 0 {
-		return false
-	}
-
-	for dir := 0; dir < 4; dir++ {
-		if calculateActualAttacks(pos, idx, dir)&enemyDiagonalSliders != 0 {
-			return true
-		}
-	}
-	return false
+	return scanRayForAttack(pos, idx, SouthWest, enemyColor, targets) ||
+		scanRayForAttack(pos, idx, SouthEast, enemyColor, targets) ||
+		scanRayForAttack(pos, idx, NorthWest, enemyColor, targets) ||
+		scanRayForAttack(pos, idx, NorthEast, enemyColor, targets)
 }
 
 func isRankAttackedByEnemy(pos *Position, index int8, enemyColor int8) bool {
-	rankBase := RankFromIdx(index) * 8
-	rankMask := uint64(0xFF) << (rankBase) // Mask for the entire rank
+	targets := (pos.rookBoard | pos.queenBoard) & pos.OccupancyMask(enemyColor)
 
-	// Combine enemy rooks and queens into one bitboard
-	enemyRookOrQueen := (pos.rookBoard | pos.queenBoard) & pos.OccupancyMask(enemyColor) & rankMask
-
-	if enemyRookOrQueen&rankMask == 0 {
-		return false
-	}
-
-	rankOccupied := pos.occupied & rankMask
-
-	msb := mostSignificantBit(enemyRookOrQueen)
-	if index > msb {
-		leftMask := (uint64(1) << index) - 1
-		blockersLeft := rankOccupied & leftMask
-		if msb >= mostSignificantBit(blockersLeft) {
-			return true
-		}
-	}
-
-	lsb := leastSignificantOne(enemyRookOrQueen)
-	if index < lsb {
-		rightMask := ^((uint64(1) << (index + 1)) - 1)
-		blockersRight := rankOccupied & rightMask
-
-		if lsb <= leastSignificantOne(blockersRight) {
-			return true
-		}
-	}
-
-	return false
+	return scanRayForAttack(pos, index, West, enemyColor, targets) ||
+		scanRayForAttack(pos, index, East, enemyColor, targets)
 }
 
 func isFileAttackedByEnemy(pos *Position, index int8, enemyColor int8) bool {
-	file := index % 8
-	fileMask := uint64(0x0101010101010101) << file // Mask for the entire rank
+	targets := (pos.rookBoard | pos.queenBoard) & pos.OccupancyMask(enemyColor)
 
-	enemyRookOrQueen := (pos.rookBoard | pos.queenBoard) & pos.OccupancyMask(enemyColor) & fileMask
-
-	if fileMask&enemyRookOrQueen == 0 {
-		return false
-	}
-
-	fileOccupied := pos.occupied & fileMask
-
-	topMask := uint64(0xFFFFFFFFFFFFFFFF) << (index + 8)
-
-	msb := mostSignificantBit(enemyRookOrQueen)
-	lsb := leastSignificantOne(enemyRookOrQueen & topMask)
-	if index < msb {
-		blockersTop := fileOccupied & topMask
-		if lsb <= leastSignificantOne(blockersTop) {
-			return true
-		}
-	}
-
-	if index > msb {
-
-		bottomMask := uint64(0xFFFFFFFFFFFFFFFF) >> (64 - index)
-		blockersBottom := fileOccupied & bottomMask
-
-		if msb >= mostSignificantBit(blockersBottom) {
-			return true
-		}
-	}
-
-	return false
+	return scanRayForAttack(pos, index, North, enemyColor, targets) ||
+		scanRayForAttack(pos, index, South, enemyColor, targets)
 }
 
 // verify if the square is attacked by king

--- a/internal/engine.go
+++ b/internal/engine.go
@@ -34,6 +34,29 @@ func (e *Engine) StartGame() {}
 
 func (e *Engine) Move() {}
 
+func (e *Engine) isCastleMove(pieceType int8, move Move) bool {
+	return pieceType == King && absInt8(move.EndIdx()-move.StartIdx()) == 2
+}
+
+func (e *Engine) isCastlePathSafe(pos *Position, move Move) bool {
+	initialColor := pos.activeColor
+	if IsKingInCheck(pos, initialColor) {
+		return false
+	}
+
+	step := int8(1)
+	if move.EndIdx() < move.StartIdx() {
+		step = -1
+	}
+
+	intermediateMove := NewMove(Piece(initialColor|King), move.StartIdx(), move.StartIdx()+step, NormalMove)
+	history := e.positionUpdater.MakeMove(pos, intermediateMove)
+	isIntermediateSquareSafe := !IsKingInCheck(pos, initialColor)
+	e.positionUpdater.UnMakeMove(pos, history)
+
+	return isIntermediateSquareSafe
+}
+
 func (e *Engine) LegalMoves(pos *Position) []Move {
 	var moves []Move
 
@@ -71,22 +94,39 @@ func (e *Engine) LegalMoves(pos *Position) []Move {
 
 		for _, pseudoLegalMoveIdx := range pseudoLegalMoves {
 			initialColor := pos.activeColor
-			pseudoLegalMove := NewMove(Piece(pos.activeColor|pieceType), idx, pseudoLegalMoveIdx, NormalMove)
-
-			// skip further checks if not needed
-			if !pos.IsCheck() && !e.positionUpdater.IsMoveAffectsKing(pos, pseudoLegalMove, pos.activeColor) {
-				moves = append(moves, pseudoLegalMove)
-				continue
+			candidateMoves := []Move{
+				NewMove(Piece(pos.activeColor|pieceType), idx, pseudoLegalMoveIdx, NormalMove),
 			}
 
-			history := e.positionUpdater.MakeMove(pos, pseudoLegalMove)
-
-			if !IsKingInCheck(pos, initialColor) { // check is the new position that the initial color is not in check
-				moves = append(moves, pseudoLegalMove)
+			if pieceType == Pawn && isPromotionSquare(pos.activeColor, pseudoLegalMoveIdx) {
+				candidateMoves = []Move{
+					NewMove(Piece(pos.activeColor|pieceType), idx, pseudoLegalMoveIdx, QueenPromotion),
+					NewMove(Piece(pos.activeColor|pieceType), idx, pseudoLegalMoveIdx, KnightPromotion),
+					NewMove(Piece(pos.activeColor|pieceType), idx, pseudoLegalMoveIdx, BishopPromotion),
+					NewMove(Piece(pos.activeColor|pieceType), idx, pseudoLegalMoveIdx, RookPromotion),
+				}
 			}
 
-			e.positionUpdater.UnMakeMove(pos, history)
-			history = nil
+			for _, pseudoLegalMove := range candidateMoves {
+				if e.isCastleMove(pieceType, pseudoLegalMove) && !e.isCastlePathSafe(pos, pseudoLegalMove) {
+					continue
+				}
+
+				// skip further checks if not needed
+				if !pos.IsCheck() && !e.positionUpdater.IsMoveAffectsKing(pos, pseudoLegalMove, pos.activeColor) {
+					moves = append(moves, pseudoLegalMove)
+					continue
+				}
+
+				history := e.positionUpdater.MakeMove(pos, pseudoLegalMove)
+
+				if !IsKingInCheck(pos, initialColor) { // check is the new position that the initial color is not in check
+					moves = append(moves, pseudoLegalMove)
+				}
+
+				e.positionUpdater.UnMakeMove(pos, history)
+				history = nil
+			}
 		}
 
 		piecesMask &^= 1 << idx

--- a/internal/engine_legal_moves_test.go
+++ b/internal/engine_legal_moves_test.go
@@ -1,0 +1,181 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEngine_LegalMoves_Regressions(t *testing.T) {
+	data := map[string]struct {
+		fen           string
+		expectedMoves []string
+	}{
+		"Start position": {
+			fen: FenStartPos,
+			expectedMoves: []string{
+				"a2a3", "a2a4", "b2b3", "b2b4", "c2c3", "c2c4", "d2d3", "d2d4",
+				"e2e3", "e2e4", "f2f3", "f2f4", "g2g3", "g2g4", "h2h3", "h2h4",
+				"b1a3", "b1c3", "g1f3", "g1h3",
+			},
+		},
+		"Perft position 2 exact root moves": {
+			fen: "r3k2r/p1ppqpb1/bn2pnp1/2PN4/1p2P3/2N2Q1p/PPPB2PP/R3K2R w KQkq - 0 1",
+			expectedMoves: []string{
+				"a1b1", "a1c1", "a1d1", "e1c1", "e1d1", "e1f2", "h1f1", "h1g1",
+				"a2a3", "a2a4", "b2b3", "c3a4", "c3b1", "c3b5", "c3d1", "c3e2",
+				"c5b6", "c5c6", "d2c1", "d2e3", "d2f4", "d2g5", "d2h6", "d5b4",
+				"d5b6", "d5c7", "d5e3", "d5e7", "d5f4", "d5f6", "e4e5", "f3d1",
+				"f3d3", "f3e2", "f3e3", "f3f1", "f3f2", "f3f4", "f3f5", "f3f6",
+				"f3g3", "f3g4", "f3h3", "f3h5", "g2g3", "g2g4", "g2h3",
+			},
+		},
+		"Check evasions from perft position 4": {
+			fen: "r3k2r/Pppp1ppp/1b3nbN/nP6/BBP1P3/q4N2/Pp1P2PP/R2Q1RK1 w kq - 0 1",
+			expectedMoves: []string{
+				"b4c5",
+				"c4c5",
+				"d2d4",
+				"f1f2",
+				"f3d4",
+				"g1h1",
+			},
+		},
+		"Perft position 3 exact root moves": {
+			fen: "8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1",
+			expectedMoves: []string{
+				"a5a4", "a5a6", "b4a4", "b4b1", "b4b2", "b4b3", "b4c4",
+				"b4d4", "b4e4", "b4f4", "e2e3", "e2e4", "g2g3", "g2g4",
+			},
+		},
+		"Perft position 5 exact root moves": {
+			fen: "rnbq1k1r/pp1Pbppp/2p5/8/2B5/8/PPP1NnPP/RNBQK2R w KQ - 1 8",
+			expectedMoves: []string{
+				"a2a3", "a2a4", "b1a3", "b1c3", "b1d2", "b2b3", "b2b4", "c1d2",
+				"c1e3", "c1f4", "c1g5", "c1h6", "c2c3", "c4a6", "c4b3", "c4b5",
+				"c4d3", "c4d5", "c4e6", "c4f7", "d1d2", "d1d3", "d1d4", "d1d5",
+				"d1d6", "d7c8b", "d7c8n", "d7c8q", "d7c8r", "e1d2", "e1f1", "e1f2",
+				"e1g1", "e2c3", "e2d4", "e2f4", "e2g1", "e2g3", "g2g3", "g2g4",
+				"h1f1", "h1g1", "h2h3", "h2h4",
+			},
+		},
+		"Perft position 6 exact root moves": {
+			fen: "r4rk1/1pp1qppp/p1np1n2/2b1p1B1/2B1P1b1/2NP1N2/PPP1QPPP/R4RK1 w - - 0 10",
+			expectedMoves: []string{
+				"a1b1", "a1c1", "a1d1", "a1e1", "a2a3", "a2a4", "b2b3", "b2b4",
+				"c3a4", "c3b1", "c3b5", "c3d1", "c3d5", "c4a6", "c4b3", "c4b5",
+				"c4d5", "c4e6", "c4f7", "d3d4", "e2d1", "e2d2", "e2e1", "e2e3",
+				"f1b1", "f1c1", "f1d1", "f1e1", "f3d2", "f3d4", "f3e1", "f3e5",
+				"f3h4", "g1h1", "g2g3", "g5c1", "g5d2", "g5e3", "g5f4", "g5f6",
+				"g5h4", "g5h6", "h2h3", "h2h4",
+			},
+		},
+		"Promotion root moves": {
+			fen: "2r1k3/3P4/8/8/8/8/8/4K3 w - - 0 1",
+			expectedMoves: []string{
+				"d7c8b", "d7c8n", "d7c8q", "d7c8r",
+				"d7d8b", "d7d8n", "d7d8q", "d7d8r",
+				"d7e8b", "d7e8n", "d7e8q", "d7e8r",
+				"e1d1", "e1d2", "e1e2", "e1f1", "e1f2",
+			},
+		},
+		"Illegal en passant discovered check": {
+			fen: "4r1k1/8/8/3pP3/8/8/8/4K3 w - d6 0 1",
+			expectedMoves: []string{
+				"e1d1", "e1d2", "e1e2", "e1f1", "e1f2", "e5e6",
+			},
+		},
+		"Legal en passant available": {
+			fen: "4k3/8/8/3pP3/8/8/8/4K3 w - d6 0 1",
+			expectedMoves: []string{
+				"e1d1", "e1d2", "e1e2", "e1f1", "e1f2", "e5d6", "e5e6",
+			},
+		},
+		"Cannot castle through check": {
+			fen: "5rk1/8/8/8/8/8/8/R3K2R w KQ - 0 1",
+			expectedMoves: []string{
+				"a1a2", "a1a3", "a1a4", "a1a5", "a1a6", "a1a7", "a1a8", "a1b1", "a1c1", "a1d1",
+				"e1c1", "e1d1", "e1d2", "e1e2",
+				"h1f1", "h1g1", "h1h2", "h1h3", "h1h4", "h1h5", "h1h6", "h1h7", "h1h8",
+			},
+		},
+		"Cannot castle while in check": {
+			fen: "4r1k1/8/8/8/8/8/8/R3K2R w KQ - 0 1",
+			expectedMoves: []string{
+				"e1d1", "e1d2", "e1f1", "e1f2",
+			},
+		},
+		"Double check only king moves": {
+			fen: "4r2k/8/8/1b6/8/8/4K3/8 w - - 0 1",
+			expectedMoves: []string{
+				"e2d1",
+				"e2d2",
+				"e2f2",
+				"e2f3",
+			},
+		},
+		"Pinned knight cannot move": {
+			fen: "4r2k/8/8/8/8/8/4N3/4K3 w - - 0 1",
+			expectedMoves: []string{
+				"e1d1",
+				"e1d2",
+				"e1f1",
+				"e1f2",
+			},
+		},
+	}
+
+	engine := NewEngine()
+
+	for name, d := range data {
+		t.Run(name, func(t *testing.T) {
+			pos, err := NewPositionFromFEN(d.fen)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			assert.ElementsMatch(t, d.expectedMoves, movesToUci(engine.LegalMoves(pos)))
+		})
+	}
+}
+
+func TestEngine_LegalMoves_KnownPositionCounts(t *testing.T) {
+	data := map[string]struct {
+		fen           string
+		expectedCount int
+	}{
+		"Perft position 2": {
+			fen:           "r3k2r/p1ppqpb1/bn2pnp1/2PN4/1p2P3/2N2Q1p/PPPB2PP/R3K2R w KQkq - 0 1",
+			expectedCount: 47,
+		},
+		"Perft position 3": {
+			fen:           "8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1",
+			expectedCount: 14,
+		},
+		"Perft position 4": {
+			fen:           "r3k2r/Pppp1ppp/1b3nbN/nP6/BBP1P3/q4N2/Pp1P2PP/R2Q1RK1 w kq - 0 1",
+			expectedCount: 6,
+		},
+		"Perft position 5": {
+			fen:           "rnbq1k1r/pp1Pbppp/2p5/8/2B5/8/PPP1NnPP/RNBQK2R w KQ - 1 8",
+			expectedCount: 44,
+		},
+		"Perft position 6": {
+			fen:           "r4rk1/1pp1qppp/p1np1n2/2b1p1B1/2B1P1b1/2NP1N2/PPP1QPPP/R4RK1 w - - 0 10",
+			expectedCount: 44,
+		},
+	}
+
+	engine := NewEngine()
+
+	for name, d := range data {
+		t.Run(name, func(t *testing.T) {
+			pos, err := NewPositionFromFEN(d.fen)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			assert.Len(t, engine.LegalMoves(pos), d.expectedCount)
+		})
+	}
+}

--- a/internal/engine_perft_test.go
+++ b/internal/engine_perft_test.go
@@ -1,0 +1,66 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEngine_MoveGenerationTest_Regressions(t *testing.T) {
+	// MoveGenerationTest() uses an internal depth convention where:
+	// depth=2 matches standard perft(1), depth=3 matches perft(2), etc.
+	data := map[string]struct {
+		fen      string
+		depth    int
+		expected uint64
+	}{
+		"Start position depth 2": {
+			fen:      FenStartPos,
+			depth:    2,
+			expected: 20,
+		},
+		"Start position depth 3": {
+			fen:      FenStartPos,
+			depth:    3,
+			expected: 400,
+		},
+		"Start position depth 4": {
+			fen:      FenStartPos,
+			depth:    4,
+			expected: 8902,
+		},
+		"Perft position 2 depth 3": {
+			fen:      "r3k2r/p1ppqpb1/bn2pnp1/2PN4/1p2P3/2N2Q1p/PPPB2PP/R3K2R w KQkq - 0 1",
+			depth:    3,
+			expected: 1955,
+		},
+		"Perft position 3 depth 4": {
+			fen:      "8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1",
+			depth:    4,
+			expected: 2812,
+		},
+		"Perft position 4 depth 3": {
+			fen:      "r3k2r/Pppp1ppp/1b3nbN/nP6/BBP1P3/q4N2/Pp1P2PP/R2Q1RK1 w kq - 0 1",
+			depth:    3,
+			expected: 264,
+		},
+		"Promotion position depth 3": {
+			fen:      "2r1k3/3P4/8/8/8/8/8/4K3 w - - 0 1",
+			depth:    3,
+			expected: 117,
+		},
+	}
+
+	engine := NewEngine()
+
+	for name, d := range data {
+		t.Run(name, func(t *testing.T) {
+			pos, err := NewPositionFromFEN(d.fen)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			assert.Equal(t, d.expected, engine.MoveGenerationTest(pos, d.depth))
+		})
+	}
+}

--- a/internal/engine_test.go
+++ b/internal/engine_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"fmt"
 	"testing"
 )
 
@@ -30,13 +29,4 @@ func BenchmarkEngine_LegalMoves(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		engine.LegalMoves(pos)
 	}
-}
-
-func TestCustom(t *testing.T) {
-	var fen string
-	fen = "r1bqkbnr/1ppppppp/8/p7/8/P2KP3/1PPP1PPP/RNB1QBnR b KQkq - 0 1"
-	pos, _ := NewPositionFromFEN(fen)
-	engine := NewEngine()
-
-	fmt.Println(movesToUci(engine.LegalMoves(pos)))
 }

--- a/internal/move.go
+++ b/internal/move.go
@@ -47,11 +47,32 @@ func (m Move) UCI() string {
 	startRank, startFile := RankAndFile(m.StartIdx())
 	endRank, endFile := RankAndFile(m.EndIdx())
 
-	return fmt.Sprintf(
+	uci := fmt.Sprintf(
 		"%c%d%c%d",
 		'a'+startFile,
 		startRank+1,
 		'a'+endFile,
 		endRank+1,
 	)
+
+	switch m.flag {
+	case QueenPromotion:
+		return uci + "q"
+	case KnightPromotion:
+		return uci + "n"
+	case BishopPromotion:
+		return uci + "b"
+	case RookPromotion:
+		return uci + "r"
+	default:
+		return uci
+	}
+}
+
+func isPromotionSquare(color int8, idx int8) bool {
+	if color == White {
+		return idx >= A8 && idx <= H8
+	}
+
+	return idx >= A1 && idx <= H1
 }

--- a/internal/position-updater.go
+++ b/internal/position-updater.go
@@ -50,6 +50,17 @@ func (updater *PositionUpdater) MakeMove(pos *Position, move Move) *MoveHistory 
 	// update position
 	updatePieceOnBoard(pos, startPiece, startPieceIdx, endPieceIdx)
 
+	switch move.flag {
+	case QueenPromotion:
+		pos.setPieceAt(endPieceIdx, Piece(pos.activeColor|Queen))
+	case KnightPromotion:
+		pos.setPieceAt(endPieceIdx, Piece(pos.activeColor|Knight))
+	case BishopPromotion:
+		pos.setPieceAt(endPieceIdx, Piece(pos.activeColor|Bishop))
+	case RookPromotion:
+		pos.setPieceAt(endPieceIdx, Piece(pos.activeColor|Rook))
+	}
+
 	// King move -> update king pos and castleRights
 	if startPieceType == King {
 		if pos.activeColor == White {

--- a/internal/position-updater_test.go
+++ b/internal/position-updater_test.go
@@ -395,6 +395,4 @@ func TestPositionUpdater_UnMakeMove(t *testing.T) {
 		assert.Equal(t, whiteKingSafety, pos.whiteKingSafety)
 		assert.Equal(t, blackKingSafety, pos.blackKingSafety)
 	})
-
-	draw(kingAttacksMask[D4])
 }


### PR DESCRIPTION
Closes #1

## What changed
- fixed sliding attack detection for legal move validation
- implemented promotion move expansion and promotion-aware make/UCI handling
- enforced castling legality through attacked intermediate squares and while in check
- added exact legal move regressions for perft positions and tricky FENs
- added pawn promotion move-generator tests
- added shallow perft regression tests for recursive correctness

## Verification
- go test ./...
