### PR TITLE
Improve king move filtering in move generation

### DIFF
--- a/docs/benchmark-history.md
+++ b/docs/benchmark-history.md
@@ -84,6 +84,7 @@ Older benchmark suites are kept in [Historical Results](#historical-results).
 | [v17](#current-v17) | 2026-03-31 | Perft position 3 | 7 | hot | off | 178,633,661 | 6.21s | -0.09s (-1.4%) |
 | [v18](#current-v18) | 2026-03-31 | Perft position 3 | 7 | hot | off | 178,633,661 | 5.71s | -0.50s (-8.0%) |
 | [v19](#current-v19) | 2026-03-31 | Perft position 3 | 7 | hot | off | 178,633,661 | 5.65s | -0.06s (-1.0%) |
+| [v20](#current-v20) | 2026-03-31 | Perft position 3 | 7 | hot | off | 178,633,661 | 5.54s | -0.11s (-1.9%) |
 
 Recorded samples:
 
@@ -93,8 +94,42 @@ Recorded samples:
 - `v17`: `6.190472756s`, `6.22881615s`
 - `v18`: `5.777905319s`, `5.651284934s`
 - `v19`: `5.650972876s`
+- `v20`: `5.544416355s`
 
 ## Optimization Log
+
+<a id="current-v20"></a>
+### v20
+
+Optimizations applied:
+
+- prefiltered king targets in `appendKingMoves(...)` against enemy pawn, knight, and king attacks before falling back to per-target slider checks
+- replaced pawn quiet-push occupancy checks based on `PieceAt(...)` with direct occupied-bitboard tests
+
+Benchmark command:
+
+```bash
+BENCH_DEPTH=7 BENCH_MODE=hot BENCH_WARMUP=1 BENCH_NO_PERFT_TRICKS=1 ./scripts/bench-perft.sh
+```
+
+Recorded output:
+
+```text
+FEN: 8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1
+Depth: 7
+Mode: hot
+Warmup: 1
+Perft tricks: false
+Nodes: 178633661
+Elapsed: 5.544416355s
+CPU profile: .codex-tmp/bench-perft.cpu.prof
+```
+
+Interpretation:
+
+- bulk-filtering obvious non-slider king attacks before the per-target legality loop paid on the benchmark FEN
+- direct occupancy checks for pawn pushes were neutral-to-helpful in this combination
+- this is the new best no-tricks hot reference
 
 <a id="current-v19"></a>
 ### v19

--- a/docs/benchmark-learnings.md
+++ b/docs/benchmark-learnings.md
@@ -4,20 +4,20 @@ This file records practical lessons from the perft optimization work so future s
 
 ## Current Best Known Result
 
-- Best raw benchmark so far: `benchmark-v19`
-- Best hot benchmark so far: `benchmark-v19`
+- Best raw benchmark so far: `benchmark-v20`
+- Best hot benchmark so far: `benchmark-v20`
 - Target: `Perft position 3`
 - FEN: `8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1`
 - Mode: `BENCH_NO_PERFT_TRICKS=1`
 - Depth: `7`
 - Nodes: `178,633,661`
-- Time: `5.650972876s`
+- Time: `5.544416355s`
 
 Current preferred reference:
 
 - Harness: `hot`
-- Samples: `5.650972876s`, `5.706223702s`
-- Recorded reference: `5.65s` to `5.71s`
+- Samples: `5.544416355s`
+- Recorded reference: `5.54s`
 
 ## Strategy Context
 
@@ -150,6 +150,16 @@ Takeaway:
 
 - In this codebase, moving hot-path metadata from "large struct returned and passed by value" to "caller-owned buffer passed by pointer" is worthwhile.
 - Move-materialization splits can pay if they remove real repeated classification work in the inner loop; the failed earlier attempts were too helper-heavy without removing enough hot-path decisions.
+
+### v20
+
+- Prefiltering king targets against enemy pawn, knight, and king attacks before the remaining slider checks paid.
+- On this codebase, direct occupied-bitboard tests for pawn quiet pushes were acceptable in combination with that king-target prefilter.
+
+Takeaway:
+
+- `appendKingMoves(...)` and `isSquareAttacked(...)` were a real enough hotspot that removing obvious non-slider-attacked king targets up front paid on the benchmark FEN.
+- The useful part of the change was not a broad movegen refactor; it was a narrow reduction in per-target king-legality work.
 
 ## What Did Not Pay
 

--- a/internal/movegen/legal-move-generator.go
+++ b/internal/movegen/legal-move-generator.go
@@ -67,17 +67,60 @@ func sliderTargetsMask(pos *Position, idx int8, pieceType int8, friendlyOcc uint
 	}
 }
 
+const (
+	notAFile uint64 = 0xFEFEFEFEFEFEFEFE
+	notHFile uint64 = 0x7F7F7F7F7F7F7F7F
+)
+
 func (g *PseudoLegalMoveGenerator) appendKingMoves(pos *Position, piece Piece, kingIdx int8, enemyColor int8, enemyKingMask uint64, info *positionAnalysis, dst []Move, count int) int {
 	friendlyOcc := pos.OccupancyMask(pos.ActiveColor())
 	targets := kingAttacksMask[kingIdx] &^ friendlyOcc &^ enemyKingMask
 	occWithoutKing := pos.Occupied() &^ (uint64(1) << kingIdx)
+
+	var enemyOcc uint64
+	if enemyColor == White {
+		enemyOcc = pos.WhiteOccupied()
+	} else {
+		enemyOcc = pos.BlackOccupied()
+	}
+
+	enemyPawns := pos.PawnBoard() & enemyOcc
+	var pawnAttacks uint64
+	if enemyColor == White {
+		pawnAttacks = ((enemyPawns & notAFile) << 7) | ((enemyPawns & notHFile) << 9)
+	} else {
+		pawnAttacks = ((enemyPawns & notHFile) >> 7) | ((enemyPawns & notAFile) >> 9)
+	}
+
+	var knightAttacks uint64
+	enemyKnights := pos.KnightBoard() & enemyOcc
+	for enemyKnights != 0 {
+		sq := int8(bits.TrailingZeros64(enemyKnights))
+		enemyKnights &^= 1 << sq
+		knightAttacks |= knightAttacksMask[sq]
+	}
+
+	var enemyKingIdx int8
+	if enemyColor == White {
+		enemyKingIdx = pos.WhiteKingIdx()
+	} else {
+		enemyKingIdx = pos.BlackKingIdx()
+	}
+
+	targets &^= pawnAttacks | knightAttacks | kingAttacksMask[enemyKingIdx]
+
+	rookQueens := (pos.RookBoard() | pos.QueenBoard()) & enemyOcc
+	bishopQueens := (pos.BishopBoard() | pos.QueenBoard()) & enemyOcc
 
 	for targets != 0 {
 		targetIdx := int8(bits.TrailingZeros64(targets))
 		targets &^= 1 << targetIdx
 
 		occ := occWithoutKing &^ (uint64(1) << targetIdx)
-		if isSquareAttacked(pos, targetIdx, enemyColor, occ) {
+		if rookQueens != 0 && rookAttacksMagic(targetIdx, occ)&rookQueens != 0 {
+			continue
+		}
+		if bishopQueens != 0 && bishopAttacksMagic(targetIdx, occ)&bishopQueens != 0 {
 			continue
 		}
 
@@ -138,11 +181,12 @@ func (g *PseudoLegalMoveGenerator) appendPawnMoves(pos *Position, positionUpdate
 	var promotionTargets uint64
 	var epTarget uint64
 
+	occ := pos.Occupied()
 	if pos.ActiveColor() == White {
 		oneStep := idx + 8
-		if oneStep < 64 && pos.PieceAt(oneStep) == NoPiece {
+		if occ&(uint64(1)<<oneStep) == 0 {
 			quietTargets |= uint64(1) << oneStep
-			if idx >= A2 && idx <= H2 && pos.PieceAt(idx+16) == NoPiece {
+			if idx >= A2 && idx <= H2 && occ&(uint64(1)<<(idx+16)) == 0 {
 				quietTargets |= uint64(1) << (idx + 16)
 			}
 		}
@@ -152,9 +196,9 @@ func (g *PseudoLegalMoveGenerator) appendPawnMoves(pos *Position, positionUpdate
 		}
 	} else {
 		oneStep := idx - 8
-		if oneStep >= 0 && pos.PieceAt(oneStep) == NoPiece {
+		if occ&(uint64(1)<<oneStep) == 0 {
 			quietTargets |= uint64(1) << oneStep
-			if idx >= A7 && idx <= H7 && pos.PieceAt(idx-16) == NoPiece {
+			if idx >= A7 && idx <= H7 && occ&(uint64(1)<<(idx-16)) == 0 {
 				quietTargets |= uint64(1) << (idx - 16)
 			}
 		}


### PR DESCRIPTION
## Summary
- closes #6
- prefilter king targets against enemy pawn, knight, and king attacks before the remaining slider legality checks
- switch pawn quiet-push occupancy checks to direct occupied-bitboard tests
- update benchmark docs with the new v20 hot no-tricks reference

## Validation
- go test ./...

## Benchmarks
- command: BENCH_DEPTH=7 BENCH_MODE=hot BENCH_WARMUP=1 BENCH_NO_PERFT_TRICKS=1 ./scripts/bench-perft.sh
- nodes: 178633661
- elapsed: 5.544416355s
- result vs current reference: better (v19 was around 5.65s)

## Risks / Follow-ups
- the king-target prefilter should stay under regression coverage because it partially duplicates attack logic before the remaining slider checks
- the pawn occupancy bitboard change was landed together with the king prefilter, so any future regression hunt should benchmark them independently if needed
