### PR TITLE
Add search and evaluation scaffolding

### DIFF
--- a/docs/codebase-overview.md
+++ b/docs/codebase-overview.md
@@ -21,9 +21,9 @@ It is not a full playing engine yet. Search, evaluation, self-play control, and 
 - `internal/engine`
   Owns orchestration: public engine API, perft recursion, and perft TT wiring.
 - `internal/search`
-  Reserved for future search.
+  Owns search types and future search logic.
 - `internal/eval`
-  Reserved for future evaluation.
+  Owns score semantics and future static evaluation.
 - `internal/lichess`
   Reserved for future integration with Lichess.
 
@@ -33,7 +33,7 @@ It is not a full playing engine yet. Search, evaluation, self-play control, and 
 - `board.Move` and `board.MoveHistory` are the move and undo records.
 - `board.MoveApplier` applies and undoes moves.
 - `movegen.PseudoLegalMoveGenerator` owns both pseudo-legal helpers and legal move generation.
-- `engine.Engine` wires `movegen` and `board` together for public use.
+- `engine.Engine` wires `movegen`, `board`, `eval`, and `search` together for public use.
 
 The dependency direction is intentional:
 
@@ -126,6 +126,7 @@ Responsibilities:
 
 - public `Engine` construction
 - `LegalMoves(...)`
+- future `BestMoveDepth(...)` / `BestMoveTime(...)` search entrypoints
 - `PerftDivide(...)`
 - recursive perft traversal
 - optional perft TT and depth-2 bulk counting when tricks are enabled
@@ -154,6 +155,7 @@ That is the standard Go layout and is preferable to separate `tests/` subdirecto
 - package boundaries are now explicit
 - board mutation is isolated from move generation
 - legal generation is no longer mixed into engine orchestration
+- search/eval scaffolding can now evolve without mixing search concepts into `movegen` or `board`
 - updater and movegen hot paths have direct regression coverage
 - benchmark workflow is simple and repeatable
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -2,12 +2,17 @@ package engine
 
 import (
 	board "chessV2/internal/board"
+	"chessV2/internal/eval"
 	"chessV2/internal/movegen"
+	"chessV2/internal/search"
+	"time"
 )
 
 type Engine struct {
 	moveGenerator   *movegen.PseudoLegalMoveGenerator
 	positionUpdater board.MoveApplier
+	evaluator       eval.Evaluator
+	searcher        search.Searcher
 	usePerftTricks  bool
 }
 
@@ -20,10 +25,14 @@ const (
 func NewEngine() *Engine {
 	moveGenerator := movegen.NewPseudoLegalMoveGenerator()
 	positionUpdater := board.NewPositionUpdater()
+	evaluator := eval.NewZeroEvaluator()
+	searcher := search.NewAlphaBetaSearcher(moveGenerator, positionUpdater, evaluator)
 
 	return &Engine{
 		moveGenerator:   moveGenerator,
 		positionUpdater: positionUpdater,
+		evaluator:       evaluator,
+		searcher:        searcher,
 		usePerftTricks:  true,
 	}
 }
@@ -37,9 +46,27 @@ func (e *Engine) SetPerftTricks(enabled bool) {
 	e.positionUpdater = board.NewPlainPositionUpdater()
 }
 
-func (e *Engine) StartGame() {}
+func (e *Engine) StartGame() {
+	e.searcher.NewGame()
+}
 
 func (e *Engine) Move() {}
+
+func (e *Engine) BestMoveDepth(pos *board.Position, depth int) (board.Move, error) {
+	result, err := e.searcher.Search(pos, search.Limits{Depth: depth})
+	if err != nil {
+		return board.Move{}, err
+	}
+	return result.BestMove, nil
+}
+
+func (e *Engine) BestMoveTime(pos *board.Position, moveTime time.Duration) (board.Move, error) {
+	result, err := e.searcher.Search(pos, search.Limits{MoveTime: moveTime})
+	if err != nil {
+		return board.Move{}, err
+	}
+	return result.BestMove, nil
+}
 
 func (e *Engine) LegalMoves(pos *board.Position) []board.Move {
 	var buf [MaxLegalMoves]board.Move

--- a/internal/eval/README.md
+++ b/internal/eval/README.md
@@ -1,3 +1,15 @@
 # Eval
 
-Reserved for position evaluation and scoring heuristics.
+Owns static evaluation and scoring semantics.
+
+Current scope:
+
+- score type and score constants
+- evaluator interface
+- zero evaluator scaffolding
+
+Planned scope:
+
+- material scoring
+- piece-square tables
+- later positional heuristics

--- a/internal/eval/evaluator.go
+++ b/internal/eval/evaluator.go
@@ -1,0 +1,18 @@
+package eval
+
+import board "chessV2/internal/board"
+
+type Evaluator interface {
+	Evaluate(pos *board.Position) Score
+}
+
+type ZeroEvaluator struct{}
+
+func NewZeroEvaluator() *ZeroEvaluator {
+	return &ZeroEvaluator{}
+}
+
+func (e *ZeroEvaluator) Evaluate(pos *board.Position) Score {
+	return DrawScore
+}
+

--- a/internal/eval/score.go
+++ b/internal/eval/score.go
@@ -1,0 +1,25 @@
+package eval
+
+// Score is expressed in centipawns from the side-to-move perspective.
+// Positive values favor the side to move, negative values favor the opponent.
+type Score int32
+
+const (
+	DrawScore Score = 0
+
+	// MateScore is the base mate value used by search.
+	// Future search code should offset it by ply so shorter mates are preferred.
+	MateScore Score = 30000
+
+	// InfinityScore is a practical search bound above any normal static score.
+	InfinityScore Score = 32000
+)
+
+func MateIn(ply int) Score {
+	return MateScore - Score(ply)
+}
+
+func MatedIn(ply int) Score {
+	return -MateScore + Score(ply)
+}
+

--- a/internal/search/README.md
+++ b/internal/search/README.md
@@ -1,3 +1,17 @@
 # Search
 
-Reserved for search code (move ordering, alpha-beta, TT, iterative deepening).
+Owns search code and search-facing types.
+
+Current scope:
+
+- search limits/results/stats types
+- alpha-beta searcher scaffolding
+
+Planned scope:
+
+- negamax
+- alpha-beta pruning
+- iterative deepening
+- move ordering
+- quiescence
+- search TT

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -1,0 +1,54 @@
+package search
+
+import (
+	"errors"
+	board "chessV2/internal/board"
+	"chessV2/internal/eval"
+	"chessV2/internal/movegen"
+	"time"
+)
+
+var ErrNotImplemented = errors.New("search not implemented")
+
+type Limits struct {
+	Depth    int
+	MoveTime time.Duration
+}
+
+type Stats struct {
+	Nodes uint64
+	Depth int
+	Time  time.Duration
+}
+
+type Result struct {
+	BestMove board.Move
+	Score    eval.Score
+	Stats    Stats
+}
+
+type Searcher interface {
+	Search(pos *board.Position, limits Limits) (Result, error)
+	NewGame()
+}
+
+type AlphaBetaSearcher struct {
+	moveGenerator   *movegen.PseudoLegalMoveGenerator
+	positionUpdater board.MoveApplier
+	evaluator       eval.Evaluator
+}
+
+func NewAlphaBetaSearcher(moveGenerator *movegen.PseudoLegalMoveGenerator, positionUpdater board.MoveApplier, evaluator eval.Evaluator) *AlphaBetaSearcher {
+	return &AlphaBetaSearcher{
+		moveGenerator:   moveGenerator,
+		positionUpdater: positionUpdater,
+		evaluator:       evaluator,
+	}
+}
+
+func (s *AlphaBetaSearcher) Search(pos *board.Position, limits Limits) (Result, error) {
+	return Result{}, ErrNotImplemented
+}
+
+func (s *AlphaBetaSearcher) NewGame() {}
+


### PR DESCRIPTION
## Summary
- closes #10
- add initial search and evaluation scaffolding
- define score semantics for centipawns, mate scores, and draw score
- add engine-facing BestMoveDepth and BestMoveTime API shape
- update codebase overview and package READMEs to reflect the new search/eval scaffolding

## Validation
- go test ./...

## Risks / Follow-ups
- search itself is still intentionally unimplemented in this slice
- future slices will replace the stub alpha-beta searcher with real depth-limited and time-limited search
