### PR TITLE
Add basic static evaluation

### DIFF
--- a/docs/codebase-overview.md
+++ b/docs/codebase-overview.md
@@ -23,7 +23,7 @@ It is not a full playing engine yet. Search, evaluation, self-play control, and 
 - `internal/search`
   Owns search types and future search logic.
 - `internal/eval`
-  Owns score semantics and future static evaluation.
+  Owns score semantics and static evaluation.
 - `internal/lichess`
   Reserved for future integration with Lichess.
 
@@ -156,6 +156,7 @@ That is the standard Go layout and is preferable to separate `tests/` subdirecto
 - board mutation is isolated from move generation
 - legal generation is no longer mixed into engine orchestration
 - search/eval scaffolding can now evolve without mixing search concepts into `movegen` or `board`
+- static evaluation now has a concrete minimal baseline instead of a pure placeholder
 - updater and movegen hot paths have direct regression coverage
 - benchmark workflow is simple and repeatable
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -25,7 +25,7 @@ const (
 func NewEngine() *Engine {
 	moveGenerator := movegen.NewPseudoLegalMoveGenerator()
 	positionUpdater := board.NewPositionUpdater()
-	evaluator := eval.NewZeroEvaluator()
+	evaluator := eval.NewStaticEvaluator()
 	searcher := search.NewAlphaBetaSearcher(moveGenerator, positionUpdater, evaluator)
 
 	return &Engine{

--- a/internal/eval/README.md
+++ b/internal/eval/README.md
@@ -7,9 +7,10 @@ Current scope:
 - score type and score constants
 - evaluator interface
 - zero evaluator scaffolding
+- basic static evaluator with:
+  - material scoring
+  - piece-square tables
 
 Planned scope:
 
-- material scoring
-- piece-square tables
 - later positional heuristics

--- a/internal/eval/evaluator.go
+++ b/internal/eval/evaluator.go
@@ -16,3 +16,137 @@ func (e *ZeroEvaluator) Evaluate(pos *board.Position) Score {
 	return DrawScore
 }
 
+type StaticEvaluator struct{}
+
+func NewStaticEvaluator() *StaticEvaluator {
+	return &StaticEvaluator{}
+}
+
+var pieceValues = [7]Score{
+	0,   // no piece
+	0,   // king
+	900, // queen
+	100, // pawn
+	320, // knight
+	330, // bishop
+	500, // rook
+}
+
+var pawnTable = [64]Score{
+	0, 0, 0, 0, 0, 0, 0, 0,
+	50, 50, 50, 50, 50, 50, 50, 50,
+	10, 10, 20, 30, 30, 20, 10, 10,
+	5, 5, 10, 25, 25, 10, 5, 5,
+	0, 0, 0, 20, 20, 0, 0, 0,
+	5, -5, -10, 0, 0, -10, -5, 5,
+	5, 10, 10, -20, -20, 10, 10, 5,
+	0, 0, 0, 0, 0, 0, 0, 0,
+}
+
+var knightTable = [64]Score{
+	-50, -40, -30, -30, -30, -30, -40, -50,
+	-40, -20, 0, 0, 0, 0, -20, -40,
+	-30, 0, 10, 15, 15, 10, 0, -30,
+	-30, 5, 15, 20, 20, 15, 5, -30,
+	-30, 0, 15, 20, 20, 15, 0, -30,
+	-30, 5, 10, 15, 15, 10, 5, -30,
+	-40, -20, 0, 5, 5, 0, -20, -40,
+	-50, -40, -30, -30, -30, -30, -40, -50,
+}
+
+var bishopTable = [64]Score{
+	-20, -10, -10, -10, -10, -10, -10, -20,
+	-10, 0, 0, 0, 0, 0, 0, -10,
+	-10, 0, 5, 10, 10, 5, 0, -10,
+	-10, 5, 5, 10, 10, 5, 5, -10,
+	-10, 0, 10, 10, 10, 10, 0, -10,
+	-10, 10, 10, 10, 10, 10, 10, -10,
+	-10, 5, 0, 0, 0, 0, 5, -10,
+	-20, -10, -10, -10, -10, -10, -10, -20,
+}
+
+var rookTable = [64]Score{
+	0, 0, 0, 5, 5, 0, 0, 0,
+	-5, 0, 0, 0, 0, 0, 0, -5,
+	-5, 0, 0, 0, 0, 0, 0, -5,
+	-5, 0, 0, 0, 0, 0, 0, -5,
+	-5, 0, 0, 0, 0, 0, 0, -5,
+	-5, 0, 0, 0, 0, 0, 0, -5,
+	5, 10, 10, 10, 10, 10, 10, 5,
+	0, 0, 0, 0, 0, 0, 0, 0,
+}
+
+var queenTable = [64]Score{
+	-20, -10, -10, -5, -5, -10, -10, -20,
+	-10, 0, 0, 0, 0, 0, 0, -10,
+	-10, 0, 5, 5, 5, 5, 0, -10,
+	-5, 0, 5, 5, 5, 5, 0, -5,
+	0, 0, 5, 5, 5, 5, 0, -5,
+	-10, 5, 5, 5, 5, 5, 0, -10,
+	-10, 0, 5, 0, 0, 0, 0, -10,
+	-20, -10, -10, -5, -5, -10, -10, -20,
+}
+
+var kingTable = [64]Score{
+	-30, -40, -40, -50, -50, -40, -40, -30,
+	-30, -40, -40, -50, -50, -40, -40, -30,
+	-30, -40, -40, -50, -50, -40, -40, -30,
+	-30, -40, -40, -50, -50, -40, -40, -30,
+	-20, -30, -30, -40, -40, -30, -30, -20,
+	-10, -20, -20, -20, -20, -20, -20, -10,
+	20, 20, 0, 0, 0, 0, 20, 20,
+	20, 30, 10, 0, 0, 10, 30, 20,
+}
+
+func mirrorForBlack(idx int8) int8 {
+	return idx ^ 56
+}
+
+func pieceSquareValue(pieceType int8, idx int8, isWhite bool) Score {
+	tableIdx := idx
+	if !isWhite {
+		tableIdx = mirrorForBlack(idx)
+	}
+
+	switch pieceType {
+	case board.Pawn:
+		return pawnTable[tableIdx]
+	case board.Knight:
+		return knightTable[tableIdx]
+	case board.Bishop:
+		return bishopTable[tableIdx]
+	case board.Rook:
+		return rookTable[tableIdx]
+	case board.Queen:
+		return queenTable[tableIdx]
+	case board.King:
+		return kingTable[tableIdx]
+	default:
+		return 0
+	}
+}
+
+func (e *StaticEvaluator) Evaluate(pos *board.Position) Score {
+	whiteScore := DrawScore
+	blackScore := DrawScore
+
+	for idx := int8(0); idx < 64; idx++ {
+		piece := pos.PieceAt(idx)
+		if piece == board.NoPiece {
+			continue
+		}
+
+		pieceType := piece.Type()
+		score := pieceValues[pieceType] + pieceSquareValue(pieceType, idx, piece.IsWhite())
+		if piece.IsWhite() {
+			whiteScore += score
+		} else {
+			blackScore += score
+		}
+	}
+
+	if pos.ActiveColor() == board.White {
+		return whiteScore - blackScore
+	}
+	return blackScore - whiteScore
+}

--- a/internal/eval/evaluator_test.go
+++ b/internal/eval/evaluator_test.go
@@ -1,0 +1,62 @@
+package eval
+
+import (
+	board "chessV2/internal/board"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStaticEvaluatorEvaluate(t *testing.T) {
+	evaluator := NewStaticEvaluator()
+
+	tests := map[string]struct {
+		fen       string
+		assertion func(t *testing.T, score Score)
+	}{
+		"empty material balance is draw": {
+			fen: "4k3/8/8/8/8/8/8/4K3 w - - 0 1",
+			assertion: func(t *testing.T, score Score) {
+				assert.Equal(t, DrawScore, score)
+			},
+		},
+		"extra white queen is positive for white to move": {
+			fen: "4k3/8/8/8/8/8/4Q3/4K3 w - - 0 1",
+			assertion: func(t *testing.T, score Score) {
+				assert.Greater(t, score, DrawScore)
+			},
+		},
+		"extra white queen is negative for black to move": {
+			fen: "4k3/8/8/8/8/8/4Q3/4K3 b - - 0 1",
+			assertion: func(t *testing.T, score Score) {
+				assert.Less(t, score, DrawScore)
+			},
+		},
+		"centralized knight scores better than rim knight": {
+			fen: "4k3/8/8/3N4/8/8/8/4K3 w - - 0 1",
+			assertion: func(t *testing.T, center Score) {
+				rimPos, err := board.NewPositionFromFEN("4k3/8/8/8/8/8/N7/4K3 w - - 0 1")
+				assert.NoError(t, err)
+				rim := evaluator.Evaluate(rimPos)
+				assert.Greater(t, center, rim)
+			},
+		},
+		"mirrored extra black rook is positive for black to move": {
+			fen: "4k3/8/8/8/8/8/8/r3K3 b - - 0 1",
+			assertion: func(t *testing.T, score Score) {
+				assert.Greater(t, score, DrawScore)
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			pos, err := board.NewPositionFromFEN(tt.fen)
+			assert.NoError(t, err)
+
+			score := evaluator.Evaluate(pos)
+			tt.assertion(t, score)
+		})
+	}
+}
+


### PR DESCRIPTION
## Summary
- closes #9
- add a first static evaluator with material scoring and simple piece-square tables
- normalize evaluation from the side-to-move perspective
- add deterministic evaluation tests on a small FEN suite
- make the engine use the static evaluator by default
- update overview/readme notes to reflect that eval is no longer just a placeholder

## Validation
- go test ./...

## Risks / Follow-ups
- this is intentionally a very small evaluation baseline, not a tuned playing-strength evaluator
- future search work may motivate adjusting piece values and piece-square tables once move selection is implemented
