### PR TITLE
Implement fixed-depth alpha-beta search

### DIFF
--- a/internal/search/README.md
+++ b/internal/search/README.md
@@ -5,12 +5,13 @@ Owns search code and search-facing types.
 Current scope:
 
 - search limits/results/stats types
-- alpha-beta searcher scaffolding
+- fixed-depth negamax alpha-beta
+- terminal handling for:
+  - checkmate
+  - stalemate
 
 Planned scope:
 
-- negamax
-- alpha-beta pruning
 - iterative deepening
 - move ordering
 - quiescence

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -9,6 +9,7 @@ import (
 )
 
 var ErrNotImplemented = errors.New("search not implemented")
+var ErrInvalidLimits = errors.New("invalid search limits")
 
 type Limits struct {
 	Depth    int
@@ -47,8 +48,94 @@ func NewAlphaBetaSearcher(moveGenerator *movegen.PseudoLegalMoveGenerator, posit
 }
 
 func (s *AlphaBetaSearcher) Search(pos *board.Position, limits Limits) (Result, error) {
-	return Result{}, ErrNotImplemented
+	if limits.Depth <= 0 {
+		return Result{}, ErrInvalidLimits
+	}
+
+	start := time.Now()
+	stats := Stats{Depth: limits.Depth}
+
+	var moves [256]board.Move
+	moveCount := s.moveGenerator.LegalMovesInto(pos, s.positionUpdater, moves[:])
+	if moveCount == 0 {
+		return Result{
+			Score: terminalScore(pos, 0),
+			Stats: Stats{
+				Nodes: 1,
+				Depth: limits.Depth,
+				Time:  time.Since(start),
+			},
+		}, nil
+	}
+
+	bestMove := moves[0]
+	bestScore := -eval.InfinityScore
+	alpha := -eval.InfinityScore
+	beta := eval.InfinityScore
+
+	for i := 0; i < moveCount; i++ {
+		move := moves[i]
+		history := s.positionUpdater.MakeMove(pos, move)
+		score := -s.negamax(pos, limits.Depth-1, 1, -beta, -alpha, &stats)
+		s.positionUpdater.UnMakeMove(pos, history)
+
+		if score > bestScore {
+			bestScore = score
+			bestMove = move
+		}
+		if score > alpha {
+			alpha = score
+		}
+	}
+
+	stats.Time = time.Since(start)
+	return Result{
+		BestMove: bestMove,
+		Score:    bestScore,
+		Stats:    stats,
+	}, nil
 }
 
 func (s *AlphaBetaSearcher) NewGame() {}
+
+func (s *AlphaBetaSearcher) negamax(pos *board.Position, depth int, ply int, alpha eval.Score, beta eval.Score, stats *Stats) eval.Score {
+	stats.Nodes++
+
+	var moves [256]board.Move
+	moveCount := s.moveGenerator.LegalMovesInto(pos, s.positionUpdater, moves[:])
+	if moveCount == 0 {
+		return terminalScore(pos, ply)
+	}
+
+	if depth == 0 {
+		return s.evaluator.Evaluate(pos)
+	}
+
+	bestScore := -eval.InfinityScore
+	for i := 0; i < moveCount; i++ {
+		move := moves[i]
+		history := s.positionUpdater.MakeMove(pos, move)
+		score := -s.negamax(pos, depth-1, ply+1, -beta, -alpha, stats)
+		s.positionUpdater.UnMakeMove(pos, history)
+
+		if score > bestScore {
+			bestScore = score
+		}
+		if score > alpha {
+			alpha = score
+		}
+		if alpha >= beta {
+			break
+		}
+	}
+
+	return bestScore
+}
+
+func terminalScore(pos *board.Position, ply int) eval.Score {
+	if movegen.IsKingInCheck(pos, pos.ActiveColor()) {
+		return eval.MatedIn(ply)
+	}
+	return eval.DrawScore
+}
 

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -1,0 +1,77 @@
+package search
+
+import (
+	board "chessV2/internal/board"
+	"chessV2/internal/eval"
+	"chessV2/internal/movegen"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAlphaBetaSearcherSearch(t *testing.T) {
+	searcher := NewAlphaBetaSearcher(
+		movegen.NewPseudoLegalMoveGenerator(),
+		board.NewPositionUpdater(),
+		eval.NewStaticEvaluator(),
+	)
+
+	tests := map[string]struct {
+		fen          string
+		depth        int
+		expectedMove string
+		assertScore  func(t *testing.T, score eval.Score)
+	}{
+		"mate in one is found": {
+			fen:          "7k/5KQ1/8/8/8/8/8/8 w - - 0 1",
+			depth:        1,
+			assertScore: func(t *testing.T, score eval.Score) {
+				assert.Greater(t, score, eval.Score(29000))
+			},
+		},
+		"winning queen capture is preferred": {
+			fen:          "3qk3/8/8/8/8/8/3Q4/4K3 w - - 0 1",
+			depth:        1,
+			expectedMove: "d2d8",
+			assertScore: func(t *testing.T, score eval.Score) {
+				assert.Greater(t, score, eval.DrawScore)
+			},
+		},
+		"stalemate position returns draw score": {
+			fen:   "7k/5Q2/6K1/8/8/8/8/8 b - - 0 1",
+			depth: 1,
+			assertScore: func(t *testing.T, score eval.Score) {
+				assert.Equal(t, eval.DrawScore, score)
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			pos, err := board.NewPositionFromFEN(tt.fen)
+			assert.NoError(t, err)
+
+			result, err := searcher.Search(pos, Limits{Depth: tt.depth})
+			assert.NoError(t, err)
+
+			tt.assertScore(t, result.Score)
+
+			if tt.expectedMove != "" {
+				assert.Equal(t, tt.expectedMove, result.BestMove.UCI())
+			}
+		})
+	}
+}
+
+func TestAlphaBetaSearcherSearchRejectsInvalidDepth(t *testing.T) {
+	searcher := NewAlphaBetaSearcher(
+		movegen.NewPseudoLegalMoveGenerator(),
+		board.NewPositionUpdater(),
+		eval.NewStaticEvaluator(),
+	)
+	pos, err := board.NewPositionFromFEN(board.FenStartPos)
+	assert.NoError(t, err)
+
+	_, err = searcher.Search(pos, Limits{Depth: 0})
+	assert.ErrorIs(t, err, ErrInvalidLimits)
+}


### PR DESCRIPTION
## Summary
- closes #8
- implement a first fixed-depth negamax alpha-beta searcher
- handle terminal nodes for checkmate and stalemate
- expose the depth-limited engine search path through the existing engine API shape
- add search tests for mate/stalemate/tactical sanity and invalid limits
- update the search package README to reflect the new baseline

## Validation
- go test ./...

## Risks / Follow-ups
- this first search slice is intentionally simple and does not include movetime search, move ordering, or quiescence yet
- depth-0 nodes still generate legal moves in order to detect terminal positions, which is acceptable for now but may be revisited once quiescence and iterative deepening are added
