### PR TITLE
Add movetime iterative deepening

### DIFF
--- a/internal/search/README.md
+++ b/internal/search/README.md
@@ -6,13 +6,13 @@ Current scope:
 
 - search limits/results/stats types
 - fixed-depth negamax alpha-beta
+- movetime-limited iterative deepening
 - terminal handling for:
   - checkmate
   - stalemate
 
 Planned scope:
 
-- iterative deepening
 - move ordering
 - quiescence
 - search TT

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -8,8 +8,8 @@ import (
 	"time"
 )
 
-var ErrNotImplemented = errors.New("search not implemented")
 var ErrInvalidLimits = errors.New("invalid search limits")
+var errSearchTimeout = errors.New("search timeout")
 
 type Limits struct {
 	Depth    int
@@ -48,12 +48,78 @@ func NewAlphaBetaSearcher(moveGenerator *movegen.PseudoLegalMoveGenerator, posit
 }
 
 func (s *AlphaBetaSearcher) Search(pos *board.Position, limits Limits) (Result, error) {
-	if limits.Depth <= 0 {
+	if limits.Depth <= 0 && limits.MoveTime <= 0 {
+		return Result{}, ErrInvalidLimits
+	}
+
+	if limits.MoveTime > 0 {
+		return s.searchIterative(pos, limits)
+	}
+	return s.searchDepth(pos, limits.Depth, time.Time{})
+}
+
+func (s *AlphaBetaSearcher) searchIterative(pos *board.Position, limits Limits) (Result, error) {
+	start := time.Now()
+	deadline := start.Add(limits.MoveTime)
+	maxDepth := limits.Depth
+	if maxDepth <= 0 {
+		maxDepth = 64
+	}
+
+	var lastComplete Result
+	var haveComplete bool
+
+	for depth := 1; depth <= maxDepth; depth++ {
+		result, err := s.searchDepth(pos, depth, deadline)
+		if err != nil {
+			if errors.Is(err, errSearchTimeout) {
+				if haveComplete {
+					lastComplete.Stats.Time = time.Since(start)
+					return lastComplete, nil
+				}
+
+				var fallbackMoves [256]board.Move
+				moveCount := s.moveGenerator.LegalMovesInto(pos, s.positionUpdater, fallbackMoves[:])
+				if moveCount == 0 {
+					return Result{
+						Score: terminalScore(pos, 0),
+						Stats: Stats{
+							Nodes: 1,
+							Time:  time.Since(start),
+						},
+					}, nil
+				}
+
+				return Result{
+					BestMove: fallbackMoves[0],
+					Score:    eval.DrawScore,
+					Stats: Stats{
+						Depth: 0,
+						Time:  time.Since(start),
+					},
+				}, nil
+			}
+			return Result{}, err
+		}
+
+		lastComplete = result
+		haveComplete = true
+		if time.Now().After(deadline) {
+			break
+		}
+	}
+
+	lastComplete.Stats.Time = time.Since(start)
+	return lastComplete, nil
+}
+
+func (s *AlphaBetaSearcher) searchDepth(pos *board.Position, depth int, deadline time.Time) (Result, error) {
+	if depth <= 0 {
 		return Result{}, ErrInvalidLimits
 	}
 
 	start := time.Now()
-	stats := Stats{Depth: limits.Depth}
+	stats := Stats{Depth: depth}
 
 	var moves [256]board.Move
 	moveCount := s.moveGenerator.LegalMovesInto(pos, s.positionUpdater, moves[:])
@@ -62,7 +128,7 @@ func (s *AlphaBetaSearcher) Search(pos *board.Position, limits Limits) (Result, 
 			Score: terminalScore(pos, 0),
 			Stats: Stats{
 				Nodes: 1,
-				Depth: limits.Depth,
+				Depth: depth,
 				Time:  time.Since(start),
 			},
 		}, nil
@@ -74,10 +140,18 @@ func (s *AlphaBetaSearcher) Search(pos *board.Position, limits Limits) (Result, 
 	beta := eval.InfinityScore
 
 	for i := 0; i < moveCount; i++ {
+		if !deadline.IsZero() && time.Now().After(deadline) {
+			return Result{}, errSearchTimeout
+		}
+
 		move := moves[i]
 		history := s.positionUpdater.MakeMove(pos, move)
-		score := -s.negamax(pos, limits.Depth-1, 1, -beta, -alpha, &stats)
+		score, err := s.negamax(pos, depth-1, 1, -beta, -alpha, &stats, deadline)
 		s.positionUpdater.UnMakeMove(pos, history)
+		if err != nil {
+			return Result{}, err
+		}
+		score = -score
 
 		if score > bestScore {
 			bestScore = score
@@ -98,25 +172,33 @@ func (s *AlphaBetaSearcher) Search(pos *board.Position, limits Limits) (Result, 
 
 func (s *AlphaBetaSearcher) NewGame() {}
 
-func (s *AlphaBetaSearcher) negamax(pos *board.Position, depth int, ply int, alpha eval.Score, beta eval.Score, stats *Stats) eval.Score {
+func (s *AlphaBetaSearcher) negamax(pos *board.Position, depth int, ply int, alpha eval.Score, beta eval.Score, stats *Stats, deadline time.Time) (eval.Score, error) {
+	if !deadline.IsZero() && time.Now().After(deadline) {
+		return 0, errSearchTimeout
+	}
+
 	stats.Nodes++
 
 	var moves [256]board.Move
 	moveCount := s.moveGenerator.LegalMovesInto(pos, s.positionUpdater, moves[:])
 	if moveCount == 0 {
-		return terminalScore(pos, ply)
+		return terminalScore(pos, ply), nil
 	}
 
 	if depth == 0 {
-		return s.evaluator.Evaluate(pos)
+		return s.evaluator.Evaluate(pos), nil
 	}
 
 	bestScore := -eval.InfinityScore
 	for i := 0; i < moveCount; i++ {
 		move := moves[i]
 		history := s.positionUpdater.MakeMove(pos, move)
-		score := -s.negamax(pos, depth-1, ply+1, -beta, -alpha, stats)
+		score, err := s.negamax(pos, depth-1, ply+1, -beta, -alpha, stats, deadline)
 		s.positionUpdater.UnMakeMove(pos, history)
+		if err != nil {
+			return 0, err
+		}
+		score = -score
 
 		if score > bestScore {
 			bestScore = score
@@ -129,7 +211,7 @@ func (s *AlphaBetaSearcher) negamax(pos *board.Position, depth int, ply int, alp
 		}
 	}
 
-	return bestScore
+	return bestScore, nil
 }
 
 func terminalScore(pos *board.Position, ply int) eval.Score {
@@ -138,4 +220,3 @@ func terminalScore(pos *board.Position, ply int) eval.Score {
 	}
 	return eval.DrawScore
 }
-

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -5,6 +5,7 @@ import (
 	"chessV2/internal/eval"
 	"chessV2/internal/movegen"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -74,4 +75,36 @@ func TestAlphaBetaSearcherSearchRejectsInvalidDepth(t *testing.T) {
 
 	_, err = searcher.Search(pos, Limits{Depth: 0})
 	assert.ErrorIs(t, err, ErrInvalidLimits)
+}
+
+func TestAlphaBetaSearcherSearchWithMoveTime(t *testing.T) {
+	searcher := NewAlphaBetaSearcher(
+		movegen.NewPseudoLegalMoveGenerator(),
+		board.NewPositionUpdater(),
+		eval.NewStaticEvaluator(),
+	)
+	pos, err := board.NewPositionFromFEN(board.FenStartPos)
+	assert.NoError(t, err)
+
+	result, err := searcher.Search(pos, Limits{MoveTime: 20 * time.Millisecond})
+	assert.NoError(t, err)
+	assert.NotEqual(t, board.Move{}, result.BestMove)
+	assert.GreaterOrEqual(t, result.Stats.Depth, 0)
+	assert.GreaterOrEqual(t, result.Stats.Time, time.Duration(0))
+}
+
+func TestAlphaBetaSearcherSearchWithDepthAndMoveTime(t *testing.T) {
+	searcher := NewAlphaBetaSearcher(
+		movegen.NewPseudoLegalMoveGenerator(),
+		board.NewPositionUpdater(),
+		eval.NewStaticEvaluator(),
+	)
+	pos, err := board.NewPositionFromFEN("3qk3/8/8/8/8/8/3Q4/4K3 w - - 0 1")
+	assert.NoError(t, err)
+
+	result, err := searcher.Search(pos, Limits{Depth: 2, MoveTime: 50 * time.Millisecond})
+	assert.NoError(t, err)
+	assert.NotEqual(t, board.Move{}, result.BestMove)
+	assert.GreaterOrEqual(t, result.Stats.Depth, 0)
+	assert.LessOrEqual(t, result.Stats.Depth, 2)
 }


### PR DESCRIPTION
## Summary
- closes #11
- add movetime-based iterative deepening on top of the fixed-depth alpha-beta searcher
- stop on deadline and return the last fully completed iteration
- keep support for pure depth-limited search
- add tests for movetime search and mixed depth+movetime limits
- update the search package README to reflect the new baseline

## Validation
- go test ./...

## Risks / Follow-ups
- timeout checks currently use simple wall-clock polling inside search, which is acceptable for now but may need refinement once search gets deeper and more optimized
- the fallback on a very early timeout returns a legal move rather than guaranteeing a completed depth-1 search, which is pragmatic for this stage
