### PR TITLE
Add UCI entrypoint and protocol support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ The project is not a full playing engine yet. Search, evaluation, self-play orch
   Simple perft entrypoint.
 - `cmd/benchperft/main.go`
   Benchmark entrypoint used by `scripts/bench-perft.sh`.
+- `cmd/uci/main.go`
+  UCI entrypoint for GUI integration and external engine tooling.
 - `docs/`
   Architecture notes, benchmark history, and optimization notes.
 
@@ -44,9 +46,17 @@ Run a direct perft divide:
 go run ./cmd/perft.go '8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1' 7
 ```
 
+Build the UCI binary:
+
+```bash
+mkdir -p ./bin
+go build -o ./bin/gochess-uci ./cmd/uci
+```
+
 ## Documentation
 
 - [Contributing](./CONTRIBUTING.md)
+- [Project Usage](./project.md)
 - [Docs Index](./docs/README.md)
 - [Codebase Overview](./docs/codebase-overview.md)
 - [Benchmark History](./docs/benchmark-history.md)

--- a/cmd/uci/main.go
+++ b/cmd/uci/main.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"chessV2/internal/engine"
+	"chessV2/internal/uci"
+	"log"
+	"os"
+)
+
+func main() {
+	srv, err := uci.NewServer(engine.NewEngine())
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if err := srv.Run(os.Stdin, os.Stdout); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/docs/codebase-overview.md
+++ b/docs/codebase-overview.md
@@ -49,8 +49,8 @@ That keeps the mutable board layer independent from the higher-level generation/
   Simple perft divide entrypoint.
 - `cmd/benchperft/main.go`
   Benchmark entrypoint used by `scripts/bench-perft.sh`.
-- `cmd/main.go`
-  Placeholder.
+- `cmd/uci/main.go`
+  UCI entrypoint for GUI integration and external engine tooling.
 
 ## Board Layer
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -5,6 +5,7 @@ import (
 	"chessV2/internal/eval"
 	"chessV2/internal/movegen"
 	"chessV2/internal/search"
+	"fmt"
 	"time"
 )
 
@@ -53,19 +54,55 @@ func (e *Engine) StartGame() {
 func (e *Engine) Move() {}
 
 func (e *Engine) BestMoveDepth(pos *board.Position, depth int) (board.Move, error) {
-	result, err := e.searcher.Search(pos, search.Limits{Depth: depth})
+	result, err := e.SearchDepth(pos, depth)
 	if err != nil {
 		return board.Move{}, err
 	}
 	return result.BestMove, nil
 }
 
+func (e *Engine) SearchDepth(pos *board.Position, depth int) (search.Result, error) {
+	return e.searcher.Search(pos, search.Limits{Depth: depth})
+}
+
 func (e *Engine) BestMoveTime(pos *board.Position, moveTime time.Duration) (board.Move, error) {
-	result, err := e.searcher.Search(pos, search.Limits{MoveTime: moveTime})
+	result, err := e.SearchTime(pos, moveTime)
 	if err != nil {
 		return board.Move{}, err
 	}
 	return result.BestMove, nil
+}
+
+func (e *Engine) SearchTime(pos *board.Position, moveTime time.Duration) (search.Result, error) {
+	return e.searcher.Search(pos, search.Limits{MoveTime: moveTime})
+}
+
+func (e *Engine) FindMoveByUCI(pos *board.Position, uci string) (board.Move, error) {
+	moves := e.LegalMoves(pos)
+	for _, move := range moves {
+		if move.UCI() == uci {
+			return move, nil
+		}
+	}
+	return board.Move{}, fmt.Errorf("illegal move: %s", uci)
+}
+
+func (e *Engine) ApplyUCIMove(pos *board.Position, uci string) error {
+	move, err := e.FindMoveByUCI(pos, uci)
+	if err != nil {
+		return err
+	}
+	e.positionUpdater.MakeMove(pos, move)
+	return nil
+}
+
+func (e *Engine) ApplyUCIMoves(pos *board.Position, moves []string) error {
+	for _, uci := range moves {
+		if err := e.ApplyUCIMove(pos, uci); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (e *Engine) LegalMoves(pos *board.Position) []board.Move {

--- a/internal/uci/result_adapter.go
+++ b/internal/uci/result_adapter.go
@@ -1,0 +1,42 @@
+package uci
+
+import (
+	"chessV2/internal/search"
+	"time"
+)
+
+type searchResultLike interface {
+	searchDepth() int
+	searchNodes() uint64
+	searchTime() time.Duration
+	searchScore() int32
+	bestMoveUCI() string
+}
+
+type resultAdapter struct {
+	result search.Result
+}
+
+func adaptResult(result search.Result) resultAdapter {
+	return resultAdapter{result: result}
+}
+
+func (r resultAdapter) searchDepth() int {
+	return r.result.Stats.Depth
+}
+
+func (r resultAdapter) searchNodes() uint64 {
+	return r.result.Stats.Nodes
+}
+
+func (r resultAdapter) searchTime() time.Duration {
+	return r.result.Stats.Time
+}
+
+func (r resultAdapter) searchScore() int32 {
+	return int32(r.result.Score)
+}
+
+func (r resultAdapter) bestMoveUCI() string {
+	return r.result.BestMove.UCI()
+}

--- a/internal/uci/server.go
+++ b/internal/uci/server.go
@@ -1,0 +1,222 @@
+package uci
+
+import (
+	"bufio"
+	board "chessV2/internal/board"
+	"chessV2/internal/engine"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	engineName   = "GoChess"
+	engineAuthor = "fmeynard"
+)
+
+type Server struct {
+	engine   *engine.Engine
+	position *board.Position
+}
+
+func NewServer(e *engine.Engine) (*Server, error) {
+	pos, err := board.NewPositionFromFEN(board.FenStartPos)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Server{
+		engine:   e,
+		position: pos,
+	}, nil
+}
+
+func (s *Server) Run(in io.Reader, out io.Writer) error {
+	scanner := bufio.NewScanner(in)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+
+		quit, err := s.handleCommand(line, out)
+		if err != nil {
+			fmt.Fprintf(out, "info string error %s\n", sanitizeInfo(err.Error()))
+		}
+		if quit {
+			return nil
+		}
+	}
+
+	return scanner.Err()
+}
+
+func (s *Server) handleCommand(line string, out io.Writer) (bool, error) {
+	fields := strings.Fields(line)
+	if len(fields) == 0 {
+		return false, nil
+	}
+
+	switch fields[0] {
+	case "uci":
+		fmt.Fprintf(out, "id name %s\n", engineName)
+		fmt.Fprintf(out, "id author %s\n", engineAuthor)
+		fmt.Fprintln(out, "uciok")
+	case "isready":
+		fmt.Fprintln(out, "readyok")
+	case "ucinewgame":
+		s.engine.StartGame()
+		return false, s.resetToStartPos()
+	case "position":
+		return false, s.handlePosition(fields[1:])
+	case "go":
+		return false, s.handleGo(fields[1:], out)
+	case "stop":
+		return false, nil
+	case "quit":
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func (s *Server) handlePosition(args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("missing position arguments")
+	}
+
+	var pos *board.Position
+	var err error
+	i := 0
+
+	switch args[0] {
+	case "startpos":
+		pos, err = board.NewPositionFromFEN(board.FenStartPos)
+		if err != nil {
+			return err
+		}
+		i = 1
+	case "fen":
+		if len(args) < 7 {
+			return fmt.Errorf("invalid fen position command")
+		}
+		fen := strings.Join(args[1:7], " ")
+		pos, err = board.NewPositionFromFEN(fen)
+		if err != nil {
+			return err
+		}
+		i = 7
+	default:
+		return fmt.Errorf("unsupported position command")
+	}
+
+	if i < len(args) {
+		if args[i] != "moves" {
+			return fmt.Errorf("unexpected token in position command: %s", args[i])
+		}
+		if err := s.engine.ApplyUCIMoves(pos, args[i+1:]); err != nil {
+			return err
+		}
+	}
+
+	s.position = pos
+	return nil
+}
+
+func (s *Server) handleGo(args []string, out io.Writer) error {
+	limits, err := parseGoLimits(args)
+	if err != nil {
+		return err
+	}
+
+	if limits.MoveTime > 0 {
+		result, err := s.engine.SearchTime(s.position, limits.MoveTime)
+		if err != nil {
+			return err
+		}
+		writeInfo(out, adaptResult(result))
+		fmt.Fprintf(out, "bestmove %s\n", result.BestMove.UCI())
+		return nil
+	}
+
+	result, err := s.engine.SearchDepth(s.position, limits.Depth)
+	if err != nil {
+		return err
+	}
+	writeInfo(out, adaptResult(result))
+	fmt.Fprintf(out, "bestmove %s\n", result.BestMove.UCI())
+	return nil
+}
+
+func (s *Server) resetToStartPos() error {
+	pos, err := board.NewPositionFromFEN(board.FenStartPos)
+	if err != nil {
+		return err
+	}
+	s.position = pos
+	return nil
+}
+
+func parseGoLimits(args []string) (limits struct {
+	Depth    int
+	MoveTime time.Duration
+}, err error) {
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "depth":
+			if i+1 >= len(args) {
+				return limits, fmt.Errorf("missing go depth value")
+			}
+			depth, convErr := strconv.Atoi(args[i+1])
+			if convErr != nil {
+				return limits, fmt.Errorf("invalid go depth value")
+			}
+			limits.Depth = depth
+			i++
+		case "movetime":
+			if i+1 >= len(args) {
+				return limits, fmt.Errorf("missing go movetime value")
+			}
+			ms, convErr := strconv.Atoi(args[i+1])
+			if convErr != nil {
+				return limits, fmt.Errorf("invalid go movetime value")
+			}
+			limits.MoveTime = time.Duration(ms) * time.Millisecond
+			i++
+		}
+	}
+
+	if limits.MoveTime <= 0 && limits.Depth <= 0 {
+		limits.Depth = 1
+	}
+
+	return limits, nil
+}
+
+func writeInfo(out io.Writer, result searchResultLike) {
+	timeMs := result.searchTime().Milliseconds()
+	score := result.searchScore()
+	if score > 29000 || score < -29000 {
+		matePly := int((30000 - absScore(score) + 1) / 2)
+		if score < 0 {
+			matePly = -matePly
+		}
+		fmt.Fprintf(out, "info depth %d nodes %d time %d score mate %d pv %s\n", result.searchDepth(), result.searchNodes(), timeMs, matePly, result.bestMoveUCI())
+		return
+	}
+
+	fmt.Fprintf(out, "info depth %d nodes %d time %d score cp %d pv %s\n", result.searchDepth(), result.searchNodes(), timeMs, score, result.bestMoveUCI())
+}
+
+func sanitizeInfo(s string) string {
+	return strings.ReplaceAll(s, "\n", " ")
+}
+
+func absScore(v int32) int32 {
+	if v < 0 {
+		return -v
+	}
+	return v
+}

--- a/internal/uci/server_test.go
+++ b/internal/uci/server_test.go
@@ -1,0 +1,70 @@
+package uci
+
+import (
+	"bytes"
+	board "chessV2/internal/board"
+	"chessV2/internal/engine"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestServerBasicHandshake(t *testing.T) {
+	e := engine.NewEngine()
+	server, err := NewServer(e)
+	assert.NoError(t, err)
+
+	var out bytes.Buffer
+	err = server.Run(strings.NewReader("uci\nisready\nquit\n"), &out)
+	assert.NoError(t, err)
+
+	output := out.String()
+	assert.Contains(t, output, "id name GoChess")
+	assert.Contains(t, output, "uciok")
+	assert.Contains(t, output, "readyok")
+}
+
+func TestServerPositionAndGoDepth(t *testing.T) {
+	e := engine.NewEngine()
+	server, err := NewServer(e)
+	assert.NoError(t, err)
+
+	var out bytes.Buffer
+	input := "position startpos moves e2e4 e7e5\ngo depth 1\nquit\n"
+	err = server.Run(strings.NewReader(input), &out)
+	assert.NoError(t, err)
+
+	output := out.String()
+	assert.Contains(t, output, "info depth 1")
+	assert.Contains(t, output, "bestmove ")
+}
+
+func TestServerPositionFenAndMoveTime(t *testing.T) {
+	e := engine.NewEngine()
+	server, err := NewServer(e)
+	assert.NoError(t, err)
+
+	var out bytes.Buffer
+	input := "position fen 7k/5KQ1/8/8/8/8/8/8 w - - 0 1\ngo movetime 10\nquit\n"
+	err = server.Run(strings.NewReader(input), &out)
+	assert.NoError(t, err)
+	assert.Contains(t, out.String(), "bestmove ")
+}
+
+func TestParseGoLimitsDefaultsDepthOne(t *testing.T) {
+	limits, err := parseGoLimits(nil)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, limits.Depth)
+}
+
+func TestEngineApplyUCIMoves(t *testing.T) {
+	e := engine.NewEngine()
+	pos, err := board.NewPositionFromFEN(board.FenStartPos)
+	assert.NoError(t, err)
+
+	err = e.ApplyUCIMoves(pos, []string{"e2e4", "e7e5"})
+	assert.NoError(t, err)
+	assert.Equal(t, board.Piece(board.Pawn|board.White), pos.PieceAt(board.E4))
+	assert.Equal(t, board.Piece(board.Pawn|board.Black), pos.PieceAt(board.E5))
+}

--- a/project.md
+++ b/project.md
@@ -1,0 +1,60 @@
+# Project Usage
+
+## Build The UCI Engine
+
+Build the UCI entrypoint:
+
+```bash
+mkdir -p ./bin
+go build -o ./bin/gochess-uci ./cmd/uci
+```
+
+## Quick Local Smoke Test
+
+You can talk to the engine directly:
+
+```bash
+printf 'uci\nisready\nposition startpos\ngo depth 1\nquit\n' | ./bin/gochess-uci
+```
+
+Expected protocol shape:
+
+- `id name GoChess`
+- `uciok`
+- `readyok`
+- one `info ...` line
+- one `bestmove ...` line
+
+## Load In A Standard GUI
+
+The engine speaks UCI, so it should load in standard UCI GUIs such as Arena, BanksiaGUI, Cute Chess GUI, or similar tools.
+
+Generic setup flow:
+
+1. Build `./bin/gochess-uci`
+2. Open your chess GUI
+3. Add a new engine
+4. Choose `UCI` as the engine protocol
+5. Point the GUI to the binary:
+   `.../gochess/bin/gochess-uci`
+6. Start a test game or analysis session
+
+## Supported Commands Today
+
+Current UCI support includes:
+
+- `uci`
+- `isready`
+- `ucinewgame`
+- `position startpos ...`
+- `position fen ...`
+- `go depth N`
+- `go movetime N`
+- `stop`
+- `quit`
+
+Current notes:
+
+- `stop` is accepted, but search is still implemented synchronously at this stage
+- advanced UCI options are not implemented yet
+- the engine is already usable in a GUI, but the protocol surface will continue to improve


### PR DESCRIPTION
## Summary
- closes #12
- add a UCI entrypoint under cmd/uci
- support the basic protocol flow needed to load the engine in a standard UCI GUI
- support: uci, isready, ucinewgame, position startpos/fen, go depth, go movetime, stop, quit
- emit info and bestmove lines
- add engine helpers to apply UCI moves through legal move generation
- document build and GUI loading in project.md

## Validation
- go test ./...

## Risks / Follow-ups
- stop is currently accepted as a safe no-op because search is still synchronous at this stage
- advanced UCI options are not implemented yet
- richer info output and real async stop handling can be added in later slices
