### PR TITLE
Handle search draws and real UCI stop

### DIFF
--- a/internal/board/position.go
+++ b/internal/board/position.go
@@ -494,3 +494,8 @@ func (p *Position) CastleRights() int8 {
 
 	return p.blackCastleRights
 }
+
+func (p *Position) Clone() *Position {
+	cloned := *p
+	return &cloned
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -54,7 +54,7 @@ func (e *Engine) StartGame() {
 func (e *Engine) Move() {}
 
 func (e *Engine) BestMoveDepth(pos *board.Position, depth int) (board.Move, error) {
-	result, err := e.SearchDepth(pos, depth)
+	result, err := e.Search(pos, search.Limits{Depth: depth})
 	if err != nil {
 		return board.Move{}, err
 	}
@@ -62,11 +62,11 @@ func (e *Engine) BestMoveDepth(pos *board.Position, depth int) (board.Move, erro
 }
 
 func (e *Engine) SearchDepth(pos *board.Position, depth int) (search.Result, error) {
-	return e.searcher.Search(pos, search.Limits{Depth: depth})
+	return e.Search(pos, search.Limits{Depth: depth})
 }
 
 func (e *Engine) BestMoveTime(pos *board.Position, moveTime time.Duration) (board.Move, error) {
-	result, err := e.SearchTime(pos, moveTime)
+	result, err := e.Search(pos, search.Limits{MoveTime: moveTime})
 	if err != nil {
 		return board.Move{}, err
 	}
@@ -74,7 +74,11 @@ func (e *Engine) BestMoveTime(pos *board.Position, moveTime time.Duration) (boar
 }
 
 func (e *Engine) SearchTime(pos *board.Position, moveTime time.Duration) (search.Result, error) {
-	return e.searcher.Search(pos, search.Limits{MoveTime: moveTime})
+	return e.Search(pos, search.Limits{MoveTime: moveTime})
+}
+
+func (e *Engine) Search(pos *board.Position, limits search.Limits) (search.Result, error) {
+	return e.searcher.Search(pos, limits)
 }
 
 func (e *Engine) FindMoveByUCI(pos *board.Position, uci string) (board.Move, error) {
@@ -103,6 +107,17 @@ func (e *Engine) ApplyUCIMoves(pos *board.Position, moves []string) error {
 		}
 	}
 	return nil
+}
+
+func (e *Engine) ApplyUCIMovesWithPositionKeys(pos *board.Position, moves []string) ([]uint64, error) {
+	keys := []uint64{pos.ZobristKey()}
+	for _, uci := range moves {
+		if err := e.ApplyUCIMove(pos, uci); err != nil {
+			return nil, err
+		}
+		keys = append(keys, pos.ZobristKey())
+	}
+	return keys, nil
 }
 
 func (e *Engine) LegalMoves(pos *board.Position) []board.Move {

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -1,19 +1,22 @@
 package search
 
 import (
-	"errors"
 	board "chessV2/internal/board"
 	"chessV2/internal/eval"
 	"chessV2/internal/movegen"
+	"errors"
 	"time"
 )
 
 var ErrInvalidLimits = errors.New("invalid search limits")
 var errSearchTimeout = errors.New("search timeout")
+var errSearchStopped = errors.New("search stopped")
 
 type Limits struct {
 	Depth    int
 	MoveTime time.Duration
+	Stop     <-chan struct{}
+	History  []uint64
 }
 
 type Stats struct {
@@ -39,6 +42,11 @@ type AlphaBetaSearcher struct {
 	evaluator       eval.Evaluator
 }
 
+type repetitionTracker struct {
+	stack  []uint64
+	counts map[uint64]uint8
+}
+
 func NewAlphaBetaSearcher(moveGenerator *movegen.PseudoLegalMoveGenerator, positionUpdater board.MoveApplier, evaluator eval.Evaluator) *AlphaBetaSearcher {
 	return &AlphaBetaSearcher{
 		moveGenerator:   moveGenerator,
@@ -55,7 +63,7 @@ func (s *AlphaBetaSearcher) Search(pos *board.Position, limits Limits) (Result, 
 	if limits.MoveTime > 0 {
 		return s.searchIterative(pos, limits)
 	}
-	return s.searchDepth(pos, limits.Depth, time.Time{})
+	return s.searchDepth(pos, limits.Depth, time.Time{}, limits.Stop, newRepetitionTracker(pos, limits.History))
 }
 
 func (s *AlphaBetaSearcher) searchIterative(pos *board.Position, limits Limits) (Result, error) {
@@ -70,9 +78,9 @@ func (s *AlphaBetaSearcher) searchIterative(pos *board.Position, limits Limits) 
 	var haveComplete bool
 
 	for depth := 1; depth <= maxDepth; depth++ {
-		result, err := s.searchDepth(pos, depth, deadline)
+		result, err := s.searchDepth(pos, depth, deadline, limits.Stop, newRepetitionTracker(pos, limits.History))
 		if err != nil {
-			if errors.Is(err, errSearchTimeout) {
+			if errors.Is(err, errSearchTimeout) || errors.Is(err, errSearchStopped) {
 				if haveComplete {
 					lastComplete.Stats.Time = time.Since(start)
 					return lastComplete, nil
@@ -113,7 +121,7 @@ func (s *AlphaBetaSearcher) searchIterative(pos *board.Position, limits Limits) 
 	return lastComplete, nil
 }
 
-func (s *AlphaBetaSearcher) searchDepth(pos *board.Position, depth int, deadline time.Time) (Result, error) {
+func (s *AlphaBetaSearcher) searchDepth(pos *board.Position, depth int, deadline time.Time, stop <-chan struct{}, repetitions *repetitionTracker) (Result, error) {
 	if depth <= 0 {
 		return Result{}, ErrInvalidLimits
 	}
@@ -138,17 +146,53 @@ func (s *AlphaBetaSearcher) searchDepth(pos *board.Position, depth int, deadline
 	bestScore := -eval.InfinityScore
 	alpha := -eval.InfinityScore
 	beta := eval.InfinityScore
+	haveComplete := false
 
 	for i := 0; i < moveCount; i++ {
-		if !deadline.IsZero() && time.Now().After(deadline) {
-			return Result{}, errSearchTimeout
+		if err := shouldStop(deadline, stop); err != nil {
+			if haveComplete {
+				stats.Time = time.Since(start)
+				return Result{
+					BestMove: bestMove,
+					Score:    bestScore,
+					Stats:    stats,
+				}, nil
+			}
+			return Result{
+				BestMove: moves[0],
+				Score:    eval.DrawScore,
+				Stats: Stats{
+					Depth: depth,
+					Time:  time.Since(start),
+				},
+			}, nil
 		}
 
 		move := moves[i]
 		history := s.positionUpdater.MakeMove(pos, move)
-		score, err := s.negamax(pos, depth-1, 1, -beta, -alpha, &stats, deadline)
+		repetitions.push(pos.ZobristKey())
+		score, err := s.negamax(pos, depth-1, 1, -beta, -alpha, &stats, deadline, stop, repetitions)
+		repetitions.pop()
 		s.positionUpdater.UnMakeMove(pos, history)
 		if err != nil {
+			if (errors.Is(err, errSearchTimeout) || errors.Is(err, errSearchStopped)) && haveComplete {
+				stats.Time = time.Since(start)
+				return Result{
+					BestMove: bestMove,
+					Score:    bestScore,
+					Stats:    stats,
+				}, nil
+			}
+			if errors.Is(err, errSearchTimeout) || errors.Is(err, errSearchStopped) {
+				return Result{
+					BestMove: moves[0],
+					Score:    eval.DrawScore,
+					Stats: Stats{
+						Depth: depth,
+						Time:  time.Since(start),
+					},
+				}, nil
+			}
 			return Result{}, err
 		}
 		score = -score
@@ -157,6 +201,7 @@ func (s *AlphaBetaSearcher) searchDepth(pos *board.Position, depth int, deadline
 			bestScore = score
 			bestMove = move
 		}
+		haveComplete = true
 		if score > alpha {
 			alpha = score
 		}
@@ -172,12 +217,15 @@ func (s *AlphaBetaSearcher) searchDepth(pos *board.Position, depth int, deadline
 
 func (s *AlphaBetaSearcher) NewGame() {}
 
-func (s *AlphaBetaSearcher) negamax(pos *board.Position, depth int, ply int, alpha eval.Score, beta eval.Score, stats *Stats, deadline time.Time) (eval.Score, error) {
-	if !deadline.IsZero() && time.Now().After(deadline) {
-		return 0, errSearchTimeout
+func (s *AlphaBetaSearcher) negamax(pos *board.Position, depth int, ply int, alpha eval.Score, beta eval.Score, stats *Stats, deadline time.Time, stop <-chan struct{}, repetitions *repetitionTracker) (eval.Score, error) {
+	if err := shouldStop(deadline, stop); err != nil {
+		return 0, err
 	}
 
 	stats.Nodes++
+	if repetitions.isThreefold() {
+		return eval.DrawScore, nil
+	}
 
 	var moves [256]board.Move
 	moveCount := s.moveGenerator.LegalMovesInto(pos, s.positionUpdater, moves[:])
@@ -193,7 +241,9 @@ func (s *AlphaBetaSearcher) negamax(pos *board.Position, depth int, ply int, alp
 	for i := 0; i < moveCount; i++ {
 		move := moves[i]
 		history := s.positionUpdater.MakeMove(pos, move)
-		score, err := s.negamax(pos, depth-1, ply+1, -beta, -alpha, stats, deadline)
+		repetitions.push(pos.ZobristKey())
+		score, err := s.negamax(pos, depth-1, ply+1, -beta, -alpha, stats, deadline, stop, repetitions)
+		repetitions.pop()
 		s.positionUpdater.UnMakeMove(pos, history)
 		if err != nil {
 			return 0, err
@@ -219,4 +269,58 @@ func terminalScore(pos *board.Position, ply int) eval.Score {
 		return eval.MatedIn(ply)
 	}
 	return eval.DrawScore
+}
+
+func shouldStop(deadline time.Time, stop <-chan struct{}) error {
+	select {
+	case <-stop:
+		return errSearchStopped
+	default:
+	}
+
+	if !deadline.IsZero() && time.Now().After(deadline) {
+		return errSearchTimeout
+	}
+
+	return nil
+}
+
+func newRepetitionTracker(pos *board.Position, history []uint64) *repetitionTracker {
+	tracker := &repetitionTracker{
+		stack:  make([]uint64, 0, len(history)+1),
+		counts: make(map[uint64]uint8, len(history)+1),
+	}
+
+	for _, key := range history {
+		tracker.push(key)
+	}
+
+	if len(tracker.stack) == 0 || tracker.stack[len(tracker.stack)-1] != pos.ZobristKey() {
+		tracker.push(pos.ZobristKey())
+	}
+
+	return tracker
+}
+
+func (t *repetitionTracker) push(key uint64) {
+	t.stack = append(t.stack, key)
+	t.counts[key]++
+}
+
+func (t *repetitionTracker) pop() {
+	lastIdx := len(t.stack) - 1
+	key := t.stack[lastIdx]
+	t.stack = t.stack[:lastIdx]
+	if t.counts[key] <= 1 {
+		delete(t.counts, key)
+		return
+	}
+	t.counts[key]--
+}
+
+func (t *repetitionTracker) isThreefold() bool {
+	if len(t.stack) == 0 {
+		return false
+	}
+	return t.counts[t.stack[len(t.stack)-1]] >= 3
 }

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -24,8 +24,8 @@ func TestAlphaBetaSearcherSearch(t *testing.T) {
 		assertScore  func(t *testing.T, score eval.Score)
 	}{
 		"mate in one is found": {
-			fen:          "7k/5KQ1/8/8/8/8/8/8 w - - 0 1",
-			depth:        1,
+			fen:   "7k/5KQ1/8/8/8/8/8/8 w - - 0 1",
+			depth: 1,
 			assertScore: func(t *testing.T, score eval.Score) {
 				assert.Greater(t, score, eval.Score(29000))
 			},
@@ -107,4 +107,32 @@ func TestAlphaBetaSearcherSearchWithDepthAndMoveTime(t *testing.T) {
 	assert.NotEqual(t, board.Move{}, result.BestMove)
 	assert.GreaterOrEqual(t, result.Stats.Depth, 0)
 	assert.LessOrEqual(t, result.Stats.Depth, 2)
+}
+
+func TestRepetitionTrackerDetectsThreefold(t *testing.T) {
+	pos, err := board.NewPositionFromFEN(board.FenStartPos)
+	assert.NoError(t, err)
+
+	history := []uint64{pos.ZobristKey()}
+	moveGenerator := movegen.NewPseudoLegalMoveGenerator()
+	updater := board.NewPositionUpdater()
+
+	for _, uci := range []string{"g1f3", "g8f6", "f3g1", "f6g8", "g1f3", "g8f6", "f3g1", "f6g8"} {
+		var moves [256]board.Move
+		moveCount := moveGenerator.LegalMovesInto(pos, updater, moves[:])
+		var selected board.Move
+		for i := 0; i < moveCount; i++ {
+			if moves[i].UCI() == uci {
+				selected = moves[i]
+				break
+			}
+		}
+
+		assert.NotEqual(t, board.Move{}, selected)
+		updater.MakeMove(pos, selected)
+		history = append(history, pos.ZobristKey())
+	}
+
+	tracker := newRepetitionTracker(pos, history)
+	assert.True(t, tracker.isThreefold())
 }

--- a/internal/uci/server.go
+++ b/internal/uci/server.go
@@ -4,10 +4,12 @@ import (
 	"bufio"
 	board "chessV2/internal/board"
 	"chessV2/internal/engine"
+	"chessV2/internal/search"
 	"fmt"
 	"io"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -17,8 +19,18 @@ const (
 )
 
 type Server struct {
-	engine   *engine.Engine
-	position *board.Position
+	mu           sync.Mutex
+	writeMu      sync.Mutex
+	engine       *engine.Engine
+	position     *board.Position
+	positionKeys []uint64
+	activeSearch *activeSearch
+}
+
+type activeSearch struct {
+	stop chan struct{}
+	done chan struct{}
+	once sync.Once
 }
 
 func NewServer(e *engine.Engine) (*Server, error) {
@@ -28,8 +40,9 @@ func NewServer(e *engine.Engine) (*Server, error) {
 	}
 
 	return &Server{
-		engine:   e,
-		position: pos,
+		engine:       e,
+		position:     pos,
+		positionKeys: []uint64{pos.ZobristKey()},
 	}, nil
 }
 
@@ -65,17 +78,22 @@ func (s *Server) handleCommand(line string, out io.Writer) (bool, error) {
 		fmt.Fprintf(out, "id author %s\n", engineAuthor)
 		fmt.Fprintln(out, "uciok")
 	case "isready":
+		s.stopSearch(true)
 		fmt.Fprintln(out, "readyok")
 	case "ucinewgame":
+		s.stopSearch(true)
 		s.engine.StartGame()
 		return false, s.resetToStartPos()
 	case "position":
+		s.stopSearch(true)
 		return false, s.handlePosition(fields[1:])
 	case "go":
 		return false, s.handleGo(fields[1:], out)
 	case "stop":
+		s.stopSearch(false)
 		return false, nil
 	case "quit":
+		s.stopSearch(true)
 		return true, nil
 	}
 
@@ -116,12 +134,17 @@ func (s *Server) handlePosition(args []string) error {
 		if args[i] != "moves" {
 			return fmt.Errorf("unexpected token in position command: %s", args[i])
 		}
-		if err := s.engine.ApplyUCIMoves(pos, args[i+1:]); err != nil {
+		positionKeys, err := s.engine.ApplyUCIMovesWithPositionKeys(pos, args[i+1:])
+		if err != nil {
 			return err
 		}
+		s.position = pos
+		s.positionKeys = positionKeys
+		return nil
 	}
 
 	s.position = pos
+	s.positionKeys = []uint64{pos.ZobristKey()}
 	return nil
 }
 
@@ -131,22 +154,19 @@ func (s *Server) handleGo(args []string, out io.Writer) error {
 		return err
 	}
 
-	if limits.MoveTime > 0 {
-		result, err := s.engine.SearchTime(s.position, limits.MoveTime)
-		if err != nil {
-			return err
-		}
-		writeInfo(out, adaptResult(result))
-		fmt.Fprintf(out, "bestmove %s\n", result.BestMove.UCI())
-		return nil
+	s.stopSearch(true)
+
+	snapshot, history := s.searchSnapshot()
+	active := &activeSearch{
+		stop: make(chan struct{}),
+		done: make(chan struct{}),
 	}
 
-	result, err := s.engine.SearchDepth(s.position, limits.Depth)
-	if err != nil {
-		return err
-	}
-	writeInfo(out, adaptResult(result))
-	fmt.Fprintf(out, "bestmove %s\n", result.BestMove.UCI())
+	s.mu.Lock()
+	s.activeSearch = active
+	s.mu.Unlock()
+
+	go s.runSearch(active, snapshot, history, limits, out)
 	return nil
 }
 
@@ -156,7 +176,80 @@ func (s *Server) resetToStartPos() error {
 		return err
 	}
 	s.position = pos
+	s.positionKeys = []uint64{pos.ZobristKey()}
 	return nil
+}
+
+func (s *Server) searchSnapshot() (*board.Position, []uint64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	history := make([]uint64, len(s.positionKeys))
+	copy(history, s.positionKeys)
+	return s.position.Clone(), history
+}
+
+func (s *Server) runSearch(active *activeSearch, pos *board.Position, history []uint64, parsedLimits struct {
+	Depth    int
+	MoveTime time.Duration
+}, out io.Writer) {
+	defer close(active.done)
+
+	result, err := s.engine.Search(pos, search.Limits{
+		Depth:    parsedLimits.Depth,
+		MoveTime: parsedLimits.MoveTime,
+		Stop:     active.stop,
+		History:  history,
+	})
+
+	s.mu.Lock()
+	if s.activeSearch == active {
+		s.activeSearch = nil
+	}
+	s.mu.Unlock()
+
+	if err != nil {
+		s.writef(out, "info string error %s\n", sanitizeInfo(err.Error()))
+		return
+	}
+
+	s.writeResult(out, result)
+}
+
+func (s *Server) stopSearch(wait bool) {
+	s.mu.Lock()
+	active := s.activeSearch
+	s.mu.Unlock()
+
+	if active == nil {
+		return
+	}
+
+	active.once.Do(func() {
+		close(active.stop)
+	})
+
+	if wait {
+		<-active.done
+	}
+}
+
+func (s *Server) writeResult(out io.Writer, result search.Result) {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
+	writeInfo(out, adaptResult(result))
+	bestMove := result.BestMove.UCI()
+	if bestMove == "" {
+		bestMove = "0000"
+	}
+	fmt.Fprintf(out, "bestmove %s\n", bestMove)
+}
+
+func (s *Server) writef(out io.Writer, format string, args ...any) {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	fmt.Fprintf(out, format, args...)
 }
 
 func parseGoLimits(args []string) (limits struct {

--- a/internal/uci/server_test.go
+++ b/internal/uci/server_test.go
@@ -52,6 +52,18 @@ func TestServerPositionFenAndMoveTime(t *testing.T) {
 	assert.Contains(t, out.String(), "bestmove ")
 }
 
+func TestServerStopCancelsRunningSearch(t *testing.T) {
+	e := engine.NewEngine()
+	server, err := NewServer(e)
+	assert.NoError(t, err)
+
+	var out bytes.Buffer
+	input := "position startpos\ngo movetime 1000\nstop\nquit\n"
+	err = server.Run(strings.NewReader(input), &out)
+	assert.NoError(t, err)
+	assert.Contains(t, out.String(), "bestmove ")
+}
+
 func TestParseGoLimitsDefaultsDepthOne(t *testing.T) {
 	limits, err := parseGoLimits(nil)
 	assert.NoError(t, err)

--- a/project.md
+++ b/project.md
@@ -55,6 +55,6 @@ Current UCI support includes:
 
 Current notes:
 
-- `stop` is accepted, but search is still implemented synchronously at this stage
+- `stop` interrupts an in-flight search and returns the best move from the last completed work available
 - advanced UCI options are not implemented yet
 - the engine is already usable in a GUI, but the protocol surface will continue to improve


### PR DESCRIPTION
## Summary
- treat threefold repetition as a draw in search using Zobrist key history
- make UCI go asynchronous and implement a real stop that returns the best available move
- document the updated GUI behavior in project.md

## Validation
- go test ./...
