### PR TITLE
Add local match runner and match history docs

### DIFF
--- a/cmd/match/main.go
+++ b/cmd/match/main.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"chessV2/internal/match"
+	"flag"
+	"fmt"
+	"os"
+	"time"
+)
+
+func main() {
+	var opponentTag string
+	var games int
+	var moveTimeMs int
+	var notes string
+
+	flag.StringVar(&opponentTag, "opponent-tag", "", "Git tag to build and use as the opponent")
+	flag.IntVar(&games, "games", 2, "Number of games to play")
+	flag.IntVar(&moveTimeMs, "movetime", 5000, "Per-move time budget in milliseconds")
+	flag.StringVar(&notes, "notes", "", "Optional notes to include in the printed markdown row")
+	flag.Parse()
+
+	repoRoot, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+
+	summary, err := match.RunMatch(match.Config{
+		RepoRoot:    repoRoot,
+		OpponentTag: opponentTag,
+		Games:       games,
+		MoveTime:    time.Duration(moveTimeMs) * time.Millisecond,
+		Notes:       notes,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Current: %s\n", summary.Current)
+	fmt.Printf("Opponent: %s\n", summary.Opponent)
+	fmt.Printf("Movetime: %s\n", summary.MoveTime)
+	fmt.Printf("Games: %d\n", summary.Games)
+	fmt.Printf("Score: %s\n", summary.ScoreSummary())
+	fmt.Printf("W/D/L: %s\n", summary.WDLSummary())
+	fmt.Printf("Markdown: %s", summary.MarkdownRow())
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,5 +4,6 @@
 - [Benchmark History](./benchmark-history.md)
 - [Benchmark Learnings](./benchmark-learnings.md)
 - [Future Optimisations](./future-optimisations.md)
+- [Match History](./match-history.md)
 
 Contributor workflow is documented at the repo root in [CONTRIBUTING.md](../CONTRIBUTING.md).

--- a/docs/match-history.md
+++ b/docs/match-history.md
@@ -1,0 +1,5 @@
+# Match History
+
+| Date (UTC) | Current | Opponent | Movetime | Games | Score | W/D/L | Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| 2026-03-31T22:33:13Z | 691a34a | self@691a34a | 50ms | 2 | 1.0/2 | 0/2/0 | sample self-play smoke run |

--- a/internal/match/history.go
+++ b/internal/match/history.go
@@ -1,0 +1,51 @@
+package match
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+type Summary struct {
+	Date          time.Time
+	Current       string
+	Opponent      string
+	MoveTime      time.Duration
+	Games         int
+	CurrentWins   int
+	Draws         int
+	CurrentLosses int
+	Notes         string
+}
+
+func (s Summary) Score() float64 {
+	return float64(s.CurrentWins) + 0.5*float64(s.Draws)
+}
+
+func (s Summary) WDLSummary() string {
+	return fmt.Sprintf("%d/%d/%d", s.CurrentWins, s.Draws, s.CurrentLosses)
+}
+
+func (s Summary) ScoreSummary() string {
+	return fmt.Sprintf("%.1f/%d", s.Score(), s.Games)
+}
+
+func (s Summary) MarkdownRow() string {
+	return fmt.Sprintf(
+		"| %s | %s | %s | %s | %d | %s | %s | %s |\n",
+		s.Date.UTC().Format(time.RFC3339),
+		escapeMarkdownCell(s.Current),
+		escapeMarkdownCell(s.Opponent),
+		s.MoveTime.Round(time.Millisecond),
+		s.Games,
+		s.ScoreSummary(),
+		s.WDLSummary(),
+		escapeMarkdownCell(s.Notes),
+	)
+}
+
+func escapeMarkdownCell(s string) string {
+	s = strings.ReplaceAll(s, "|", "\\|")
+	s = strings.ReplaceAll(s, "\n", " ")
+	return s
+}

--- a/internal/match/history_test.go
+++ b/internal/match/history_test.go
@@ -1,0 +1,28 @@
+package match
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSummaryMarkdownRow(t *testing.T) {
+	summary := Summary{
+		Date:          time.Date(2026, 3, 31, 22, 0, 0, 0, time.UTC),
+		Current:       "691a34a",
+		Opponent:      "self@691a34a",
+		MoveTime:      50 * time.Millisecond,
+		Games:         2,
+		CurrentWins:   0,
+		Draws:         2,
+		CurrentLosses: 0,
+		Notes:         "sample smoke run",
+	}
+
+	assert.Equal(
+		t,
+		"| 2026-03-31T22:00:00Z | 691a34a | self@691a34a | 50ms | 2 | 1.0/2 | 0/2/0 | sample smoke run |\n",
+		summary.MarkdownRow(),
+	)
+}

--- a/internal/match/runner.go
+++ b/internal/match/runner.go
@@ -1,0 +1,257 @@
+package match
+
+import (
+	board "chessV2/internal/board"
+	"chessV2/internal/engine"
+	"chessV2/internal/movegen"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const DefaultMoveTime = 5 * time.Second
+const defaultMaxPlies = 300
+
+type Config struct {
+	RepoRoot      string
+	OpponentTag   string
+	Games         int
+	MoveTime      time.Duration
+	Notes         string
+	CurrentLabel  string
+	CurrentBinary string
+}
+
+type binarySpec struct {
+	Label string
+	Path  string
+}
+
+func RunMatch(cfg Config) (Summary, error) {
+	if cfg.Games <= 0 {
+		return Summary{}, fmt.Errorf("games must be > 0")
+	}
+	if cfg.MoveTime <= 0 {
+		cfg.MoveTime = DefaultMoveTime
+	}
+
+	currentLabel, err := cfg.currentRevision()
+	if err != nil {
+		return Summary{}, err
+	}
+	if cfg.CurrentLabel == "" {
+		cfg.CurrentLabel = currentLabel
+	}
+
+	currentBinary, err := cfg.prepareCurrentBinary()
+	if err != nil {
+		return Summary{}, err
+	}
+
+	opponent, err := cfg.prepareOpponentBinary(currentBinary)
+	if err != nil {
+		return Summary{}, err
+	}
+
+	currentClient, err := NewUCIClient(currentBinary.Path)
+	if err != nil {
+		return Summary{}, err
+	}
+	defer currentClient.Close()
+
+	opponentClient, err := NewUCIClient(opponent.Path)
+	if err != nil {
+		return Summary{}, err
+	}
+	defer opponentClient.Close()
+
+	summary := Summary{
+		Date:     time.Now().UTC(),
+		Current:  cfg.CurrentLabel,
+		Opponent: opponent.Label,
+		MoveTime: cfg.MoveTime,
+		Games:    cfg.Games,
+		Notes:    cfg.Notes,
+	}
+
+	for game := 0; game < cfg.Games; game++ {
+		if err := currentClient.NewGame(); err != nil {
+			return Summary{}, err
+		}
+		if err := opponentClient.NewGame(); err != nil {
+			return Summary{}, err
+		}
+
+		outcome, err := playSingleGame(currentClient, opponentClient, game%2 == 0, cfg.MoveTime)
+		if err != nil {
+			return Summary{}, err
+		}
+
+		switch outcome {
+		case 1:
+			summary.CurrentWins++
+		case -1:
+			summary.CurrentLosses++
+		default:
+			summary.Draws++
+		}
+	}
+
+	return summary, nil
+}
+
+func playSingleGame(currentClient, opponentClient *UCIClient, currentIsWhite bool, moveTime time.Duration) (int, error) {
+	referee := engine.NewEngine()
+	pos, err := board.NewPositionFromFEN(board.FenStartPos)
+	if err != nil {
+		return 0, err
+	}
+
+	moves := make([]string, 0, defaultMaxPlies)
+	repetitionCount := map[uint64]int{pos.ZobristKey(): 1}
+
+	for ply := 0; ply < defaultMaxPlies; ply++ {
+		if repetitionCount[pos.ZobristKey()] >= 3 {
+			return 0, nil
+		}
+
+		legalMoves := referee.LegalMoves(pos)
+		if len(legalMoves) == 0 {
+			if movegen.IsKingInCheck(pos, pos.ActiveColor()) {
+				currentToMove := (pos.ActiveColor() == board.White) == currentIsWhite
+				if currentToMove {
+					return -1, nil
+				}
+				return 1, nil
+			}
+			return 0, nil
+		}
+
+		client := selectClient(currentClient, opponentClient, pos.ActiveColor(), currentIsWhite)
+		bestMove, err := client.BestMove(moves, moveTime)
+		if err != nil {
+			currentToMove := (pos.ActiveColor() == board.White) == currentIsWhite
+			if currentToMove {
+				return -1, nil
+			}
+			return 1, nil
+		}
+
+		if err := referee.ApplyUCIMove(pos, bestMove); err != nil {
+			currentToMove := (pos.ActiveColor() == board.White) == currentIsWhite
+			if currentToMove {
+				return -1, nil
+			}
+			return 1, nil
+		}
+
+		moves = append(moves, bestMove)
+		repetitionCount[pos.ZobristKey()]++
+	}
+
+	return 0, nil
+}
+
+func selectClient(currentClient, opponentClient *UCIClient, activeColor int8, currentIsWhite bool) *UCIClient {
+	currentToMove := (activeColor == board.White) == currentIsWhite
+	if currentToMove {
+		return currentClient
+	}
+	return opponentClient
+}
+
+func (c Config) prepareCurrentBinary() (binarySpec, error) {
+	if c.CurrentBinary != "" {
+		return binarySpec{Label: c.CurrentLabel, Path: c.CurrentBinary}, nil
+	}
+
+	outputPath := filepath.Join(c.RepoRoot, ".codex-tmp", "match", "current", "gochess-uci")
+	if err := buildUCIBinary(c.RepoRoot, c.RepoRoot, outputPath); err != nil {
+		return binarySpec{}, err
+	}
+
+	return binarySpec{Label: c.CurrentLabel, Path: outputPath}, nil
+}
+
+func (c Config) prepareOpponentBinary(current binarySpec) (binarySpec, error) {
+	if c.OpponentTag == "" {
+		return binarySpec{
+			Label: fmt.Sprintf("self@%s", current.Label),
+			Path:  current.Path,
+		}, nil
+	}
+
+	safeTag := sanitizeForPath(c.OpponentTag)
+	worktreePath := filepath.Join(c.RepoRoot, ".codex-tmp", "match", "worktrees", safeTag)
+	outputPath := filepath.Join(c.RepoRoot, ".codex-tmp", "match", "opponents", safeTag, "gochess-uci")
+
+	if err := os.RemoveAll(worktreePath); err != nil {
+		return binarySpec{}, err
+	}
+
+	if err := runCommand(c.RepoRoot, "git", "worktree", "add", "--detach", worktreePath, c.OpponentTag); err != nil {
+		return binarySpec{}, err
+	}
+	defer runCommand(c.RepoRoot, "git", "worktree", "remove", "--force", worktreePath)
+
+	if err := buildUCIBinary(c.RepoRoot, worktreePath, outputPath); err != nil {
+		return binarySpec{}, fmt.Errorf("failed to build opponent tag %s: %w", c.OpponentTag, err)
+	}
+
+	opponentRev, err := revParseShort(c.RepoRoot, c.OpponentTag)
+	if err != nil {
+		return binarySpec{}, err
+	}
+
+	return binarySpec{
+		Label: fmt.Sprintf("tag %s (%s)", c.OpponentTag, opponentRev),
+		Path:  outputPath,
+	}, nil
+}
+
+func (c Config) currentRevision() (string, error) {
+	return revParseShort(c.RepoRoot, "HEAD")
+}
+
+func buildUCIBinary(repoRoot, workdir, outputPath string) error {
+	if err := os.MkdirAll(filepath.Dir(outputPath), 0o755); err != nil {
+		return err
+	}
+
+	cmd := exec.Command("go", "build", "-o", outputPath, "./cmd/uci")
+	cmd.Dir = workdir
+	cmd.Env = append(os.Environ(), "GOCACHE="+filepath.Join(repoRoot, ".codex-tmp", "go-build-cache"))
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%w: %s", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+func runCommand(workdir string, name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	cmd.Dir = workdir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%w: %s", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+func revParseShort(workdir string, rev string) (string, error) {
+	cmd := exec.Command("git", "rev-parse", "--short", rev)
+	cmd.Dir = workdir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("%w: %s", err, strings.TrimSpace(string(out)))
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func sanitizeForPath(s string) string {
+	replacer := strings.NewReplacer("/", "-", " ", "-", ":", "-", "@", "-", "\\", "-")
+	return replacer.Replace(s)
+}

--- a/internal/match/uci_client.go
+++ b/internal/match/uci_client.go
@@ -1,0 +1,130 @@
+package match
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type UCIClient struct {
+	cmd   *exec.Cmd
+	stdin io.WriteCloser
+	lines chan string
+}
+
+func NewUCIClient(binaryPath string) (*UCIClient, error) {
+	cmd := exec.Command(binaryPath)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, err
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, err
+	}
+
+	client := &UCIClient{
+		cmd:   cmd,
+		stdin: stdin,
+		lines: make(chan string, 256),
+	}
+
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+
+	go scanLines(stdout, client.lines)
+	go scanLines(stderr, client.lines)
+
+	if err := client.send("uci"); err != nil {
+		return nil, err
+	}
+	if _, err := client.waitFor("uciok", 5*time.Second); err != nil {
+		return nil, err
+	}
+	if err := client.send("isready"); err != nil {
+		return nil, err
+	}
+	if _, err := client.waitFor("readyok", 5*time.Second); err != nil {
+		return nil, err
+	}
+
+	return client, nil
+}
+
+func (c *UCIClient) NewGame() error {
+	if err := c.send("ucinewgame"); err != nil {
+		return err
+	}
+	if err := c.send("isready"); err != nil {
+		return err
+	}
+	_, err := c.waitFor("readyok", 5*time.Second)
+	return err
+}
+
+func (c *UCIClient) BestMove(moves []string, moveTime time.Duration) (string, error) {
+	position := "position startpos"
+	if len(moves) > 0 {
+		position += " moves " + strings.Join(moves, " ")
+	}
+	if err := c.send(position); err != nil {
+		return "", err
+	}
+	if err := c.send(fmt.Sprintf("go movetime %d", moveTime.Milliseconds())); err != nil {
+		return "", err
+	}
+
+	line, err := c.waitFor("bestmove ", moveTime+5*time.Second)
+	if err != nil {
+		return "", err
+	}
+	fields := strings.Fields(line)
+	if len(fields) < 2 {
+		return "", fmt.Errorf("invalid bestmove response: %q", line)
+	}
+	return fields[1], nil
+}
+
+func (c *UCIClient) Close() error {
+	_ = c.send("quit")
+	return c.cmd.Wait()
+}
+
+func (c *UCIClient) send(line string) error {
+	_, err := fmt.Fprintln(c.stdin, line)
+	return err
+}
+
+func (c *UCIClient) waitFor(prefix string, timeout time.Duration) (string, error) {
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	for {
+		select {
+		case line, ok := <-c.lines:
+			if !ok {
+				return "", fmt.Errorf("uci process ended before %q", prefix)
+			}
+			if strings.HasPrefix(line, prefix) {
+				return line, nil
+			}
+		case <-timer.C:
+			return "", fmt.Errorf("timeout waiting for %q", prefix)
+		}
+	}
+}
+
+func scanLines(r io.Reader, out chan<- string) {
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		out <- strings.TrimSpace(scanner.Text())
+	}
+}

--- a/project.md
+++ b/project.md
@@ -58,3 +58,19 @@ Current notes:
 - `stop` interrupts an in-flight search and returns the best move from the last completed work available
 - advanced UCI options are not implemented yet
 - the engine is already usable in a GUI, but the protocol surface will continue to improve
+
+## Run Local Matches
+
+Build and run a local self-play smoke match:
+
+```bash
+go run ./cmd/match -games 2 -movetime 50 -notes "sample self-play smoke run"
+```
+
+Run the current engine against a tagged revision that already contains `cmd/uci`:
+
+```bash
+go run ./cmd/match -opponent-tag <tag> -games 4 -movetime 5000
+```
+
+The runner prints a markdown row you can copy manually into `docs/match-history.md`.


### PR DESCRIPTION
## Summary
- add a local UCI match runner for current vs self or a tagged revision
- print a markdown row instead of editing docs automatically, then record a sample result manually
- add match history docs and usage notes

## Validation
- go test ./...
- go run ./cmd/match -games 2 -movetime 50 -notes "sample self-play smoke run"

## Notes
- the recorded sample is self-play because the existing historical tags predate cmd/uci
