### PR TITLE
Add mobility to static evaluation

### DIFF
--- a/internal/eval/evaluator.go
+++ b/internal/eval/evaluator.go
@@ -1,6 +1,10 @@
 package eval
 
-import board "chessV2/internal/board"
+import (
+	board "chessV2/internal/board"
+	"chessV2/internal/movegen"
+	"math/bits"
+)
 
 type Evaluator interface {
 	Evaluate(pos *board.Position) Score
@@ -17,6 +21,16 @@ func (e *ZeroEvaluator) Evaluate(pos *board.Position) Score {
 }
 
 type StaticEvaluator struct{}
+
+var mobilityWeights = [7]Score{
+	0, // no piece
+	0, // king
+	1, // queen
+	0, // pawn
+	4, // knight
+	5, // bishop
+	2, // rook
+}
 
 func NewStaticEvaluator() *StaticEvaluator {
 	return &StaticEvaluator{}
@@ -145,8 +159,30 @@ func (e *StaticEvaluator) Evaluate(pos *board.Position) Score {
 		}
 	}
 
+	whiteScore += mobilityScore(pos, board.White)
+	blackScore += mobilityScore(pos, board.Black)
+
 	if pos.ActiveColor() == board.White {
 		return whiteScore - blackScore
 	}
 	return blackScore - whiteScore
+}
+
+func mobilityScore(pos *board.Position, color int8) Score {
+	score := DrawScore
+	for idx := int8(0); idx < 64; idx++ {
+		piece := pos.PieceAt(idx)
+		if piece == board.NoPiece || piece.Color() != color {
+			continue
+		}
+
+		weight := mobilityWeights[piece.Type()]
+		if weight == 0 {
+			continue
+		}
+
+		targets := movegen.PseudoLegalTargetsMask(pos, piece, idx)
+		score += Score(bits.OnesCount64(targets)) * weight
+	}
+	return score
 }

--- a/internal/eval/evaluator_test.go
+++ b/internal/eval/evaluator_test.go
@@ -47,6 +47,24 @@ func TestStaticEvaluatorEvaluate(t *testing.T) {
 				assert.Greater(t, score, DrawScore)
 			},
 		},
+		"centralized bishop scores better than corner bishop": {
+			fen: "4k3/8/8/8/3B4/8/8/4K3 w - - 0 1",
+			assertion: func(t *testing.T, center Score) {
+				cornerPos, err := board.NewPositionFromFEN("4k3/8/8/8/8/8/8/B3K3 w - - 0 1")
+				assert.NoError(t, err)
+				corner := evaluator.Evaluate(cornerPos)
+				assert.Greater(t, center, corner)
+			},
+		},
+		"centralized rook scores better than corner rook": {
+			fen: "4k3/8/8/8/3R4/8/8/4K3 w - - 0 1",
+			assertion: func(t *testing.T, center Score) {
+				cornerPos, err := board.NewPositionFromFEN("4k3/8/8/8/8/8/8/R3K3 w - - 0 1")
+				assert.NoError(t, err)
+				corner := evaluator.Evaluate(cornerPos)
+				assert.Greater(t, center, corner)
+			},
+		},
 	}
 
 	for name, tt := range tests {
@@ -59,4 +77,3 @@ func TestStaticEvaluatorEvaluate(t *testing.T) {
 		})
 	}
 }
-

--- a/internal/movegen/mobility.go
+++ b/internal/movegen/mobility.go
@@ -1,0 +1,21 @@
+package movegen
+
+import board "chessV2/internal/board"
+
+func PseudoLegalTargetsMask(pos *board.Position, piece board.Piece, idx int8) uint64 {
+	ensureAttackTables()
+
+	friendlyOcc := pos.OccupancyMask(piece.Color())
+	switch piece.Type() {
+	case board.Knight:
+		return knightAttacksMask[idx] &^ friendlyOcc
+	case board.Bishop:
+		return bishopAttacksMagic(idx, pos.Occupied()) &^ friendlyOcc
+	case board.Rook:
+		return rookAttacksMagic(idx, pos.Occupied()) &^ friendlyOcc
+	case board.Queen:
+		return (rookAttacksMagic(idx, pos.Occupied()) | bishopAttacksMagic(idx, pos.Occupied())) &^ friendlyOcc
+	default:
+		return 0
+	}
+}


### PR DESCRIPTION
## Summary
- add a first mobility rule to the static evaluator using pseudo-legal target masks
- score knight, bishop, rook and queen mobility with modest piece-specific weights
- add evaluator tests for more active bishop and rook placements

## Validation
- go test ./...

## Tags
- current main was tagged as score-v0 before this change
- this PR is the intended candidate for score-v1 after merge
