### PR TITLE
Add search transposition table

### DIFF
--- a/internal/search/README.md
+++ b/internal/search/README.md
@@ -7,12 +7,14 @@ Current scope:
 - search limits/results/stats types
 - fixed-depth negamax alpha-beta
 - movetime-limited iterative deepening
+- simple move ordering
+- quiescence
+- search TT
 - terminal handling for:
   - checkmate
   - stalemate
 
 Planned scope:
 
-- move ordering
-- quiescence
-- search TT
+- killer ordering
+- history heuristic

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -42,6 +42,7 @@ type AlphaBetaSearcher struct {
 	moveGenerator   *movegen.PseudoLegalMoveGenerator
 	positionUpdater board.MoveApplier
 	evaluator       eval.Evaluator
+	tt              *searchTT
 }
 
 type repetitionTracker struct {
@@ -54,6 +55,7 @@ func NewAlphaBetaSearcher(moveGenerator *movegen.PseudoLegalMoveGenerator, posit
 		moveGenerator:   moveGenerator,
 		positionUpdater: positionUpdater,
 		evaluator:       evaluator,
+		tt:              newSearchTT(),
 	}
 }
 
@@ -157,12 +159,17 @@ func (s *AlphaBetaSearcher) searchDepth(pos *board.Position, depth int, deadline
 			},
 		}, nil
 	}
-	orderMoves(pos, moves[:moveCount])
+	var ttMove board.Move
+	if entry, ok := s.tt.probe(pos.ZobristKey(), depth, 0); ok {
+		ttMove = entry.bestMove
+	}
+	orderMoves(pos, moves[:moveCount], ttMove)
 
 	bestMove := moves[0]
 	bestScore := -eval.InfinityScore
 	alpha := -eval.InfinityScore
 	beta := eval.InfinityScore
+	alphaStart := alpha
 	haveComplete := false
 
 	for i := 0; i < moveCount; i++ {
@@ -224,6 +231,12 @@ func (s *AlphaBetaSearcher) searchDepth(pos *board.Position, depth int, deadline
 		}
 	}
 
+	bound := ttBoundExact
+	if bestScore <= alphaStart {
+		bound = ttBoundUpper
+	}
+	s.tt.store(pos.ZobristKey(), depth, 0, bestScore, bound, bestMove)
+
 	stats.Time = time.Since(start)
 	return Result{
 		BestMove: bestMove,
@@ -232,7 +245,9 @@ func (s *AlphaBetaSearcher) searchDepth(pos *board.Position, depth int, deadline
 	}, nil
 }
 
-func (s *AlphaBetaSearcher) NewGame() {}
+func (s *AlphaBetaSearcher) NewGame() {
+	s.tt.clear()
+}
 
 func (s *AlphaBetaSearcher) negamax(pos *board.Position, depth int, ply int, alpha eval.Score, beta eval.Score, stats *Stats, deadline time.Time, stop <-chan struct{}, repetitions *repetitionTracker) (eval.Score, error) {
 	if err := shouldStop(deadline, stop); err != nil {
@@ -242,6 +257,30 @@ func (s *AlphaBetaSearcher) negamax(pos *board.Position, depth int, ply int, alp
 	stats.Nodes++
 	if repetitions.isThreefold() {
 		return eval.DrawScore, nil
+	}
+
+	key := pos.ZobristKey()
+	alphaStart := alpha
+	betaStart := beta
+	var ttMove board.Move
+	if entry, ok := s.tt.probe(key, depth, ply); ok {
+		ttMove = entry.bestMove
+		switch entry.bound {
+		case ttBoundExact:
+			return entry.score, nil
+		case ttBoundLower:
+			if entry.score > alpha {
+				alpha = entry.score
+			}
+		case ttBoundUpper:
+			if entry.score < beta {
+				beta = entry.score
+			}
+		}
+		if alpha >= beta {
+			stats.Cutoffs++
+			return entry.score, nil
+		}
 	}
 
 	var moves [256]board.Move
@@ -254,9 +293,10 @@ func (s *AlphaBetaSearcher) negamax(pos *board.Position, depth int, ply int, alp
 		return s.quiescence(pos, ply, alpha, beta, stats, deadline, stop, repetitions)
 	}
 
-	orderMoves(pos, moves[:moveCount])
+	orderMoves(pos, moves[:moveCount], ttMove)
 
 	bestScore := -eval.InfinityScore
+	bestMove := board.Move{}
 	for i := 0; i < moveCount; i++ {
 		move := moves[i]
 		history := s.positionUpdater.MakeMove(pos, move)
@@ -271,6 +311,7 @@ func (s *AlphaBetaSearcher) negamax(pos *board.Position, depth int, ply int, alp
 
 		if score > bestScore {
 			bestScore = score
+			bestMove = move
 		}
 		if score > alpha {
 			alpha = score
@@ -280,6 +321,14 @@ func (s *AlphaBetaSearcher) negamax(pos *board.Position, depth int, ply int, alp
 			break
 		}
 	}
+
+	bound := ttBoundExact
+	if bestScore <= alphaStart {
+		bound = ttBoundUpper
+	} else if bestScore >= betaStart {
+		bound = ttBoundLower
+	}
+	s.tt.store(key, depth, ply, bestScore, bound, bestMove)
 
 	return bestScore, nil
 }
@@ -309,7 +358,7 @@ func (s *AlphaBetaSearcher) quiescence(pos *board.Position, ply int, alpha eval.
 		return terminalScore(pos, ply), nil
 	}
 
-	orderMoves(pos, moves[:moveCount])
+	orderMoves(pos, moves[:moveCount], board.Move{})
 	for i := 0; i < moveCount; i++ {
 		move := moves[i]
 		if !isTacticalMove(pos, move) {
@@ -399,19 +448,23 @@ func (t *repetitionTracker) isThreefold() bool {
 	return t.counts[t.stack[len(t.stack)-1]] >= 3
 }
 
-func orderMoves(pos *board.Position, moves []board.Move) {
+func orderMoves(pos *board.Position, moves []board.Move, ttMove board.Move) {
 	for i := 1; i < len(moves); i++ {
 		move := moves[i]
-		score := scoreMove(pos, move)
+		score := scoreMove(pos, move, ttMove)
 		j := i - 1
-		for ; j >= 0 && score > scoreMove(pos, moves[j]); j-- {
+		for ; j >= 0 && score > scoreMove(pos, moves[j], ttMove); j-- {
 			moves[j+1] = moves[j]
 		}
 		moves[j+1] = move
 	}
 }
 
-func scoreMove(pos *board.Position, move board.Move) int {
+func scoreMove(pos *board.Position, move board.Move, ttMove board.Move) int {
+	if ttMove != (board.Move{}) && move == ttMove {
+		return 1_000_000
+	}
+
 	score := 0
 	if isCaptureMove(pos, move) {
 		captured := capturedPiece(pos, move)

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -177,8 +177,21 @@ func TestOrderMovesPrefersCaptures(t *testing.T) {
 		board.NewMove(board.Piece(board.White|board.Pawn), board.E4, board.D5, board.Capture),
 	}
 
-	orderMoves(pos, moves)
+	orderMoves(pos, moves, board.Move{})
 	assert.Equal(t, "e4d5", moves[0].UCI())
+}
+
+func TestOrderMovesPrefersTTMove(t *testing.T) {
+	pos, err := board.NewPositionFromFEN(board.FenStartPos)
+	assert.NoError(t, err)
+
+	moves := []board.Move{
+		board.NewMove(board.Piece(board.White|board.Knight), board.B1, board.C3, board.NormalMove),
+		board.NewMove(board.Piece(board.White|board.Knight), board.G1, board.F3, board.NormalMove),
+	}
+
+	orderMoves(pos, moves, moves[1])
+	assert.Equal(t, "g1f3", moves[0].UCI())
 }
 
 func TestAlphaBetaSearcherSearchWithMoveTimeRegressionGame45NeverReturnsZeroMove(t *testing.T) {

--- a/internal/search/tt.go
+++ b/internal/search/tt.go
@@ -1,0 +1,86 @@
+package search
+
+import (
+	board "chessV2/internal/board"
+	"chessV2/internal/eval"
+)
+
+const searchTTSize = 1 << 20
+const searchMatePlyWindow = 256
+
+type ttBound uint8
+
+const (
+	ttBoundExact ttBound = iota + 1
+	ttBoundLower
+	ttBoundUpper
+)
+
+type ttEntry struct {
+	key      uint64
+	depth    int16
+	score    eval.Score
+	bound    ttBound
+	bestMove board.Move
+}
+
+type searchTT struct {
+	entries []ttEntry
+	mask    uint64
+}
+
+func newSearchTT() *searchTT {
+	return &searchTT{
+		entries: make([]ttEntry, searchTTSize),
+		mask:    searchTTSize - 1,
+	}
+}
+
+func (tt *searchTT) clear() {
+	clear(tt.entries)
+}
+
+func (tt *searchTT) probe(key uint64, depth int, ply int) (ttEntry, bool) {
+	entry := tt.entries[key&tt.mask]
+	if entry.key != key || int(entry.depth) < depth {
+		return ttEntry{}, false
+	}
+	entry.score = ttScoreFromStored(entry.score, ply)
+	return entry, true
+}
+
+func (tt *searchTT) store(key uint64, depth int, ply int, score eval.Score, bound ttBound, bestMove board.Move) {
+	index := key & tt.mask
+	current := tt.entries[index]
+	if current.key == key && int(current.depth) > depth && bestMove == (board.Move{}) {
+		return
+	}
+
+	tt.entries[index] = ttEntry{
+		key:      key,
+		depth:    int16(depth),
+		score:    ttScoreForStorage(score, ply),
+		bound:    bound,
+		bestMove: bestMove,
+	}
+}
+
+func ttScoreForStorage(score eval.Score, ply int) eval.Score {
+	if score >= eval.MateScore-searchMatePlyWindow {
+		return score + eval.Score(ply)
+	}
+	if score <= -eval.MateScore+searchMatePlyWindow {
+		return score - eval.Score(ply)
+	}
+	return score
+}
+
+func ttScoreFromStored(score eval.Score, ply int) eval.Score {
+	if score >= eval.MateScore-searchMatePlyWindow {
+		return score - eval.Score(ply)
+	}
+	if score <= -eval.MateScore+searchMatePlyWindow {
+		return score + eval.Score(ply)
+	}
+	return score
+}

--- a/internal/search/tt_test.go
+++ b/internal/search/tt_test.go
@@ -1,0 +1,46 @@
+package search
+
+import (
+	board "chessV2/internal/board"
+	"chessV2/internal/eval"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSearchTTScoreRoundTripForMateScores(t *testing.T) {
+	tests := []struct {
+		name  string
+		score eval.Score
+		ply   int
+	}{
+		{name: "mate for side to move", score: eval.MateIn(3), ply: 5},
+		{name: "mated line", score: eval.MatedIn(4), ply: 7},
+		{name: "normal cp score", score: eval.Score(123), ply: 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stored := ttScoreForStorage(tt.score, tt.ply)
+			loaded := ttScoreFromStored(stored, tt.ply)
+			assert.Equal(t, tt.score, loaded)
+		})
+	}
+}
+
+func TestSearchTTProbeAndStore(t *testing.T) {
+	tt := newSearchTT()
+	key := uint64(42)
+	move := board.NewMove(board.Piece(board.White|board.Knight), board.G1, board.F3, board.NormalMove)
+
+	tt.store(key, 5, 3, eval.MateIn(2), ttBoundExact, move)
+
+	entry, ok := tt.probe(key, 5, 3)
+	assert.True(t, ok)
+	assert.Equal(t, ttBoundExact, entry.bound)
+	assert.Equal(t, move, entry.bestMove)
+	assert.Equal(t, eval.MateIn(2), entry.score)
+
+	_, ok = tt.probe(key, 6, 3)
+	assert.False(t, ok)
+}


### PR DESCRIPTION
Closes #36

## Summary
- add a dedicated search transposition table keyed by the existing Zobrist hash
- probe/store TT entries during root search and negamax, including bounds and best move
- prioritize the TT move in ordering and cover the new behavior with unit tests

## Validation
- go test ./internal/search
- go test ./...