### PR TITLE
uci: support clock-based go limits

### DIFF
--- a/internal/uci/server.go
+++ b/internal/uci/server.go
@@ -149,14 +149,13 @@ func (s *Server) handlePosition(args []string) error {
 }
 
 func (s *Server) handleGo(args []string, out io.Writer) error {
-	limits, err := parseGoLimits(args)
+	snapshot, history := s.searchSnapshot()
+	limits, err := parseGoLimits(args, snapshot.ActiveColor())
 	if err != nil {
 		return err
 	}
 
 	s.stopSearch(true)
-
-	snapshot, history := s.searchSnapshot()
 	active := &activeSearch{
 		stop: make(chan struct{}),
 		done: make(chan struct{}),
@@ -256,10 +255,19 @@ func (s *Server) writef(out io.Writer, format string, args ...any) {
 	fmt.Fprintf(out, format, args...)
 }
 
-func parseGoLimits(args []string) (limits struct {
+func parseGoLimits(args []string, activeColor int8) (limits struct {
 	Depth    int
 	MoveTime time.Duration
 }, err error) {
+	var (
+		whiteTime  time.Duration
+		blackTime  time.Duration
+		whiteInc   time.Duration
+		blackInc   time.Duration
+		movesToGo  int
+		haveClocks bool
+	)
+
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
 		case "depth":
@@ -282,7 +290,46 @@ func parseGoLimits(args []string) (limits struct {
 			}
 			limits.MoveTime = time.Duration(ms) * time.Millisecond
 			i++
+		case "wtime":
+			whiteTime, err = parseGoDurationArg(args, i+1, "wtime")
+			if err != nil {
+				return limits, err
+			}
+			haveClocks = true
+			i++
+		case "btime":
+			blackTime, err = parseGoDurationArg(args, i+1, "btime")
+			if err != nil {
+				return limits, err
+			}
+			haveClocks = true
+			i++
+		case "winc":
+			whiteInc, err = parseGoDurationArg(args, i+1, "winc")
+			if err != nil {
+				return limits, err
+			}
+			i++
+		case "binc":
+			blackInc, err = parseGoDurationArg(args, i+1, "binc")
+			if err != nil {
+				return limits, err
+			}
+			i++
+		case "movestogo":
+			if i+1 >= len(args) {
+				return limits, fmt.Errorf("missing go movestogo value")
+			}
+			movesToGo, err = strconv.Atoi(args[i+1])
+			if err != nil || movesToGo < 0 {
+				return limits, fmt.Errorf("invalid go movestogo value")
+			}
+			i++
 		}
+	}
+
+	if limits.MoveTime <= 0 && haveClocks {
+		limits.MoveTime = allocateClockMoveTime(activeColor, whiteTime, blackTime, whiteInc, blackInc, movesToGo)
 	}
 
 	if limits.MoveTime <= 0 && limits.Depth <= 0 {
@@ -290,6 +337,63 @@ func parseGoLimits(args []string) (limits struct {
 	}
 
 	return limits, nil
+}
+
+func parseGoDurationArg(args []string, valueIndex int, name string) (time.Duration, error) {
+	if valueIndex >= len(args) {
+		return 0, fmt.Errorf("missing go %s value", name)
+	}
+
+	ms, err := strconv.Atoi(args[valueIndex])
+	if err != nil || ms < 0 {
+		return 0, fmt.Errorf("invalid go %s value", name)
+	}
+
+	return time.Duration(ms) * time.Millisecond, nil
+}
+
+func allocateClockMoveTime(activeColor int8, whiteTime time.Duration, blackTime time.Duration, whiteInc time.Duration, blackInc time.Duration, movesToGo int) time.Duration {
+	remaining := whiteTime
+	increment := whiteInc
+	if activeColor == board.Black {
+		remaining = blackTime
+		increment = blackInc
+	}
+
+	if remaining <= 0 {
+		return 0
+	}
+
+	if movesToGo <= 0 {
+		movesToGo = 30
+	}
+
+	const moveOverhead = 50 * time.Millisecond
+
+	reserve := remaining / 20
+	if reserve < moveOverhead {
+		reserve = moveOverhead
+	}
+	maxBudget := remaining - reserve
+	if maxBudget <= 0 {
+		if remaining > moveOverhead {
+			return remaining - moveOverhead
+		}
+		return time.Millisecond
+	}
+
+	budget := remaining/time.Duration(movesToGo) + (increment * 3 / 4)
+	if budget <= 0 {
+		budget = time.Millisecond
+	}
+	if budget > maxBudget {
+		budget = maxBudget
+	}
+	if budget < time.Millisecond {
+		return time.Millisecond
+	}
+
+	return budget
 }
 
 func writeInfo(out io.Writer, result searchResultLike) {

--- a/internal/uci/server_test.go
+++ b/internal/uci/server_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -66,9 +67,35 @@ func TestServerStopCancelsRunningSearch(t *testing.T) {
 }
 
 func TestParseGoLimitsDefaultsDepthOne(t *testing.T) {
-	limits, err := parseGoLimits(nil)
+	limits, err := parseGoLimits(nil, board.White)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, limits.Depth)
+}
+
+func TestParseGoLimitsMoveTimeOverridesClockData(t *testing.T) {
+	limits, err := parseGoLimits([]string{"movetime", "250", "wtime", "60000", "btime", "60000"}, board.White)
+	assert.NoError(t, err)
+	assert.Equal(t, 250*time.Millisecond, limits.MoveTime)
+	assert.Zero(t, limits.Depth)
+}
+
+func TestParseGoLimitsAllocatesFromWhiteClock(t *testing.T) {
+	limits, err := parseGoLimits([]string{"wtime", "60000", "btime", "120000", "winc", "1000", "binc", "2000"}, board.White)
+	assert.NoError(t, err)
+	assert.Equal(t, 2750*time.Millisecond, limits.MoveTime)
+	assert.Zero(t, limits.Depth)
+}
+
+func TestParseGoLimitsAllocatesFromBlackClockAndMovesToGo(t *testing.T) {
+	limits, err := parseGoLimits([]string{"wtime", "60000", "btime", "90000", "winc", "1000", "binc", "2000", "movestogo", "20"}, board.Black)
+	assert.NoError(t, err)
+	assert.Equal(t, 6000*time.Millisecond, limits.MoveTime)
+	assert.Zero(t, limits.Depth)
+}
+
+func TestParseGoLimitsRejectsInvalidClockValue(t *testing.T) {
+	_, err := parseGoLimits([]string{"wtime", "-1"}, board.White)
+	assert.Error(t, err)
 }
 
 func TestEngineApplyUCIMoves(t *testing.T) {
@@ -117,6 +144,21 @@ func TestServerGoMoveTimeReturnsLegalBestMoveOnRegressionPositions(t *testing.T)
 			assert.Contains(t, legalMoves, bestMove)
 		})
 	}
+}
+
+func TestServerPositionAndGoClockTime(t *testing.T) {
+	e := engine.NewEngine()
+	server, err := NewServer(e)
+	assert.NoError(t, err)
+
+	var out bytes.Buffer
+	input := "position startpos moves e2e4\ngo wtime 60000 btime 60000 winc 1000 binc 1000\nquit\n"
+	err = server.Run(strings.NewReader(input), &out)
+	assert.NoError(t, err)
+
+	output := out.String()
+	assert.Contains(t, output, "info depth ")
+	assert.Contains(t, output, "bestmove ")
 }
 
 func parseBestMove(output string) string {

--- a/project.md
+++ b/project.md
@@ -50,13 +50,15 @@ Current UCI support includes:
 - `position fen ...`
 - `go depth N`
 - `go movetime N`
+- `go wtime <ms> btime <ms> [winc <ms>] [binc <ms>] [movestogo <n>]`
 - `stop`
 - `quit`
 
 Current notes:
 
 - `stop` interrupts an in-flight search and returns the best move from the last completed work available
-- advanced UCI options are not implemented yet
+- time controls from standard UCI GUIs are converted into an internal per-move search budget
+- advanced UCI options are otherwise not implemented yet
 - the engine is already usable in a GUI, but the protocol surface will continue to improve
 
 ## Run Local Matches


### PR DESCRIPTION
Closes #48

## Summary
- parse standard GUI clock fields from `go` commands: `wtime`, `btime`, `winc`, `binc`, and `movestogo`
- convert clock data into an internal per-move search budget based on the side to move
- keep existing `go movetime` and `go depth` behavior intact
- document the added UCI time-control support

## Validation
- `GOCACHE=/home/fab/Projects/gochess/.codex-tmp/go-build-cache go test ./internal/uci`
- `GOCACHE=/home/fab/Projects/gochess/.codex-tmp/go-build-cache go test ./...`
- smoke tested `go wtime 60000 btime 60000 winc 1000 binc 1000` against the UCI binary