### PR TITLE
eval: penalize hanging and under-defended pieces

### DIFF
--- a/internal/eval/evaluator.go
+++ b/internal/eval/evaluator.go
@@ -72,6 +72,8 @@ const (
 	doubledPawnPenaltyEG   Score = 8
 )
 
+const kingSafetyTradeValue Score = 2000
+
 var passedPawnBonusMG = [8]Score{0, 0, 8, 14, 24, 40, 70, 0}
 var passedPawnBonusEG = [8]Score{0, 0, 16, 28, 48, 80, 130, 0}
 
@@ -363,6 +365,9 @@ func pieceSafetyScore(pos *board.Position, color int8) Score {
 
 		attackers := attackCountOnSquare(pos, enemyColor, idx)
 		defenders := attackCountOnSquare(pos, color, idx)
+		leastAttacker := leastAttackerValueOnSquare(pos, enemyColor, idx)
+		leastDefender := leastAttackerValueOnSquare(pos, color, idx)
+		pieceValue := tradeSafetyValue(piece.Type())
 
 		if defenders > 0 {
 			bonus := protectedPieceWeights[piece.Type()]
@@ -382,6 +387,19 @@ func pieceSafetyScore(pos *board.Position, color int8) Score {
 		} else if attackers > defenders {
 			penalty += exposedPieceWeights[piece.Type()] * Score(attackers-defenders)
 		}
+
+		if leastAttacker > 0 && leastAttacker < pieceValue {
+			tradeLoss := pieceValue - leastAttacker
+			switch {
+			case defenders == 0:
+				penalty += tradeLoss
+			case leastDefender == 0:
+				penalty += tradeLoss * 3 / 4
+			case leastDefender > leastAttacker:
+				penalty += tradeLoss * 3 / 5
+			}
+		}
+
 		score -= penalty
 	}
 
@@ -529,6 +547,35 @@ func attackCountOnSquare(pos *board.Position, color, square int8) int {
 		}
 	}
 	return count
+}
+
+func leastAttackerValueOnSquare(pos *board.Position, color, square int8) Score {
+	lowest := Score(0)
+	squareMask := uint64(1) << square
+
+	for idx := int8(0); idx < 64; idx++ {
+		piece := pos.PieceAt(idx)
+		if piece == board.NoPiece || piece.Color() != color {
+			continue
+		}
+		if movegen.PieceAttackMask(pos, piece, idx)&squareMask == 0 {
+			continue
+		}
+
+		value := tradeSafetyValue(piece.Type())
+		if lowest == 0 || value < lowest {
+			lowest = value
+		}
+	}
+
+	return lowest
+}
+
+func tradeSafetyValue(pieceType int8) Score {
+	if pieceType == board.King {
+		return kingSafetyTradeValue
+	}
+	return pieceValues[pieceType]
 }
 
 func pawnShieldPenalty(pos *board.Position, color, kingIdx int8, phase int) Score {

--- a/internal/eval/evaluator_test.go
+++ b/internal/eval/evaluator_test.go
@@ -119,6 +119,15 @@ func TestStaticEvaluatorEvaluate(t *testing.T) {
 				assert.Greater(t, protected, unprotected)
 			},
 		},
+		"bishop attacked by cheaper piece with bad defense is heavily penalized": {
+			fen: "4k3/8/8/8/8/3p4/4B3/3QK3 w - - 0 1",
+			assertion: func(t *testing.T, exposed Score) {
+				safePos, err := board.NewPositionFromFEN("4k3/8/8/8/8/8/4B3/3QK3 w - - 0 1")
+				assert.NoError(t, err)
+				safe := evaluator.Evaluate(safePos)
+				assert.Less(t, exposed, safe)
+			},
+		},
 		"healthy pawn chain scores better than isolated doubled pawns": {
 			fen: "4k3/8/8/8/8/2P5/3PP3/4K3 w - - 0 1",
 			assertion: func(t *testing.T, healthy Score) {

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -140,6 +140,21 @@ func TestAlphaBetaSearcherQuiescenceAvoidsPoisonedPawn(t *testing.T) {
 	assert.Greater(t, result.Stats.QuiescenceNodes, uint64(0))
 }
 
+func TestAlphaBetaSearcherQuiescenceAvoidsPoisonedQueenCapture(t *testing.T) {
+	searcher := NewAlphaBetaSearcher(
+		movegen.NewPseudoLegalMoveGenerator(),
+		board.NewPositionUpdater(),
+		eval.NewStaticEvaluator(),
+	)
+	pos, err := board.NewPositionFromFEN("3rk3/3p4/8/8/8/8/3Q4/4K3 w - - 0 1")
+	assert.NoError(t, err)
+
+	result, err := searcher.Search(pos, Limits{Depth: 1})
+	assert.NoError(t, err)
+	assert.NotEqual(t, "d2d7", result.BestMove.UCI())
+	assert.Greater(t, result.Stats.QuiescenceNodes, uint64(0))
+}
+
 func TestRepetitionTrackerDetectsThreefold(t *testing.T) {
 	pos, err := board.NewPositionFromFEN(board.FenStartPos)
 	assert.NoError(t, err)


### PR DESCRIPTION
Closes #50

## Summary
- strengthen `pieceSafetyScore` with attacker/defender value awareness instead of relying only on attack counts
- penalize pieces that can be traded off unfavorably by a cheaper attacker, especially when hanging or badly defended
- add regression coverage for exposed bishop evaluation and poisoned queen captures in search

## Validation
- `GOCACHE=/home/fab/Projects/gochess/.codex-tmp/go-build-cache go test ./internal/eval ./internal/search`
- `GOCACHE=/home/fab/Projects/gochess/.codex-tmp/go-build-cache go test ./...`