### PR TITLE
tooling: add Stockfish swing analysis workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ GAMES ?= 10
 MOVETIME ?= 1000
 MOVE_OVERHEAD ?= 50
 NOTES ?=
+RECORD_PATH ?=
 BENCH_DEPTH ?= 7
 BENCH_MODE ?= hot
 BENCH_WARMUP ?= 1
@@ -22,6 +23,9 @@ endif
 ifneq ($(strip $(NOTES)),)
 RUNNER_FLAGS += -notes "$(NOTES)"
 endif
+ifneq ($(strip $(RECORD_PATH)),)
+RUNNER_FLAGS += -record-path $(RECORD_PATH)
+endif
 ifeq ($(MODE),plain)
 RUNNER_FLAGS += -plain
 endif
@@ -34,7 +38,7 @@ ifneq ($(strip $(BENCH_PROFILE)),)
 BENCH_PERFT_ENV += BENCH_PROFILE='$(BENCH_PROFILE)'
 endif
 
-.PHONY: help test build-uci smoke-uci runner bench-perft bench-perft-hot bench-perft-hot-no-tricks bench-perft-cold-no-tricks bench-updater-bench
+.PHONY: help test build-uci smoke-uci runner analyze-match bench-perft bench-perft-hot bench-perft-hot-no-tricks bench-perft-cold-no-tricks bench-updater-bench
 
 help:
 	@echo "Common targets:"
@@ -42,6 +46,7 @@ help:
 	@echo "  make build-uci"
 	@echo "  make smoke-uci"
 	@echo "  make runner MODE=tui CONCURRENT=5 OPPONENT_TAG=score-v1 GAMES=10 MOVETIME=1000 MOVE_OVERHEAD=50"
+	@echo "  make analyze-match RECORD_PATH=.codex-tmp/match/records.jsonl STOCKFISH=stockfish"
 	@echo "  make bench-perft BENCH_DEPTH=7 BENCH_MODE=hot BENCH_NO_PERFT_TRICKS=1"
 	@echo "  make bench-perft-hot"
 	@echo "  make bench-perft-hot-no-tricks"
@@ -56,6 +61,7 @@ help:
 	@echo "  MOVETIME=<ms>         default: $(MOVETIME)"
 	@echo "  MOVE_OVERHEAD=<ms>    default: $(MOVE_OVERHEAD)"
 	@echo "  NOTES=<text>          default: empty"
+	@echo "  RECORD_PATH=<path>    optional JSONL move log for match analysis"
 	@echo ""
 	@echo "Benchmark variables:"
 	@echo "  BENCH_DEPTH=<n>       default: $(BENCH_DEPTH)"
@@ -79,6 +85,14 @@ smoke-uci: build-uci
 
 runner:
 	GOCACHE="$(GOCACHE)" go run ./cmd/match $(RUNNER_FLAGS)
+
+STOCKFISH ?= stockfish
+ANALYZE_LIMIT ?= 20
+ANALYZE_MOVETIME ?= 250
+ANALYZE_MIN_SWING ?= 150
+
+analyze-match:
+	GOCACHE="$(GOCACHE)" go run ./cmd/analyze-match -input $(RECORD_PATH) -stockfish $(STOCKFISH) -movetime $(ANALYZE_MOVETIME) -limit $(ANALYZE_LIMIT) -min-swing $(ANALYZE_MIN_SWING)
 
 bench-perft:
 	$(BENCH_PERFT_ENV) ./scripts/bench-perft.sh

--- a/cmd/analyze-match/main.go
+++ b/cmd/analyze-match/main.go
@@ -1,0 +1,292 @@
+package main
+
+import (
+	"bufio"
+	"chessV2/internal/match"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type swing struct {
+	match.MoveRecord
+	BeforeCP int
+	AfterCP  int
+	DeltaCP  int
+	BestMove string
+}
+
+type stockfishClient struct {
+	cmd   *exec.Cmd
+	stdin io.WriteCloser
+	lines chan string
+}
+
+func main() {
+	var (
+		inputPath     string
+		stockfishPath string
+		movetimeMS    int
+		limit         int
+		minSwingCP    int
+		onlyCurrent   bool
+	)
+
+	flag.StringVar(&inputPath, "input", "", "Path to match JSONL record file")
+	flag.StringVar(&stockfishPath, "stockfish", "stockfish", "Path to stockfish binary")
+	flag.IntVar(&movetimeMS, "movetime", 250, "Stockfish analysis time per position in milliseconds")
+	flag.IntVar(&limit, "limit", 20, "Maximum number of swings to print")
+	flag.IntVar(&minSwingCP, "min-swing", 150, "Minimum centipawn swing to include")
+	flag.BoolVar(&onlyCurrent, "only-current", true, "Only report swings from current engine moves")
+	flag.Parse()
+
+	if inputPath == "" {
+		fmt.Fprintln(os.Stderr, "missing required -input")
+		os.Exit(2)
+	}
+
+	records, err := loadRecords(inputPath)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	client, err := newStockfishClient(stockfishPath)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer client.close()
+
+	swings := make([]swing, 0, len(records))
+	for _, record := range records {
+		if onlyCurrent && record.Player != "current" {
+			continue
+		}
+
+		beforeCP, bestMove, err := client.evaluate(record.FENBefore, time.Duration(movetimeMS)*time.Millisecond)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		afterCP, _, err := client.evaluate(record.FENAfter, time.Duration(movetimeMS)*time.Millisecond)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+
+		delta := beforeCP + afterCP
+		if delta < minSwingCP {
+			continue
+		}
+
+		swings = append(swings, swing{
+			MoveRecord: record,
+			BeforeCP:   beforeCP,
+			AfterCP:    afterCP,
+			DeltaCP:    delta,
+			BestMove:   bestMove,
+		})
+	}
+
+	sort.Slice(swings, func(i, j int) bool {
+		if swings[i].DeltaCP == swings[j].DeltaCP {
+			if swings[i].GameIndex == swings[j].GameIndex {
+				return swings[i].Ply < swings[j].Ply
+			}
+			return swings[i].GameIndex < swings[j].GameIndex
+		}
+		return swings[i].DeltaCP > swings[j].DeltaCP
+	})
+
+	if limit > len(swings) {
+		limit = len(swings)
+	}
+
+	for i := 0; i < limit; i++ {
+		item := swings[i]
+		fmt.Printf(
+			"#%d game=%d ply=%d delta=%dcp before=%dcp after=%dcp player=%s move=%s sf_best=%s\n",
+			i+1,
+			item.GameIndex,
+			item.Ply,
+			item.DeltaCP,
+			item.BeforeCP,
+			item.AfterCP,
+			item.Player,
+			item.Move,
+			item.BestMove,
+		)
+		fmt.Printf("  before: %s\n", item.FENBefore)
+		fmt.Printf("  after : %s\n", item.FENAfter)
+	}
+}
+
+func loadRecords(path string) ([]match.MoveRecord, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	records := make([]match.MoveRecord, 0)
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		var record match.MoveRecord
+		if err := json.Unmarshal(scanner.Bytes(), &record); err != nil {
+			return nil, err
+		}
+		records = append(records, record)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return records, nil
+}
+
+func newStockfishClient(path string) (*stockfishClient, error) {
+	cmd := exec.Command(path)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, err
+	}
+
+	client := &stockfishClient{
+		cmd:   cmd,
+		stdin: stdin,
+		lines: make(chan string, 256),
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+
+	go scanLines(stdout, client.lines)
+
+	if err := client.send("uci"); err != nil {
+		return nil, err
+	}
+	if _, err := client.waitFor("uciok", 5*time.Second); err != nil {
+		return nil, err
+	}
+	if err := client.send("isready"); err != nil {
+		return nil, err
+	}
+	if _, err := client.waitFor("readyok", 5*time.Second); err != nil {
+		return nil, err
+	}
+
+	return client, nil
+}
+
+func (c *stockfishClient) evaluate(fen string, moveTime time.Duration) (int, string, error) {
+	if err := c.send("position fen " + fen); err != nil {
+		return 0, "", err
+	}
+	if err := c.send(fmt.Sprintf("go movetime %d", moveTime.Milliseconds())); err != nil {
+		return 0, "", err
+	}
+
+	bestScore := 0
+	bestMove := ""
+	timer := time.NewTimer(moveTime + 5*time.Second)
+	defer timer.Stop()
+
+	for {
+		select {
+		case line, ok := <-c.lines:
+			if !ok {
+				return 0, "", fmt.Errorf("stockfish exited during analysis")
+			}
+			if strings.HasPrefix(line, "info ") {
+				if score, ok := parseCentipawnScore(line); ok {
+					bestScore = score
+				}
+				continue
+			}
+			if strings.HasPrefix(line, "bestmove ") {
+				fields := strings.Fields(line)
+				if len(fields) >= 2 {
+					bestMove = fields[1]
+				}
+				return bestScore, bestMove, nil
+			}
+		case <-timer.C:
+			return 0, "", fmt.Errorf("timeout waiting for stockfish bestmove")
+		}
+	}
+}
+
+func (c *stockfishClient) close() error {
+	_, _ = fmt.Fprintln(c.stdin, "quit")
+	return c.cmd.Wait()
+}
+
+func (c *stockfishClient) send(line string) error {
+	_, err := fmt.Fprintln(c.stdin, line)
+	return err
+}
+
+func (c *stockfishClient) waitFor(prefix string, timeout time.Duration) (string, error) {
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	for {
+		select {
+		case line, ok := <-c.lines:
+			if !ok {
+				return "", fmt.Errorf("stockfish ended before %q", prefix)
+			}
+			if strings.HasPrefix(line, prefix) {
+				return line, nil
+			}
+		case <-timer.C:
+			return "", fmt.Errorf("timeout waiting for %q", prefix)
+		}
+	}
+}
+
+func parseCentipawnScore(line string) (int, bool) {
+	fields := strings.Fields(line)
+	for i := 0; i < len(fields)-1; i++ {
+		if fields[i] != "score" || i+2 >= len(fields) {
+			continue
+		}
+		switch fields[i+1] {
+		case "cp":
+			value, err := strconv.Atoi(fields[i+2])
+			if err != nil {
+				return 0, false
+			}
+			return value, true
+		case "mate":
+			value, err := strconv.Atoi(fields[i+2])
+			if err != nil {
+				return 0, false
+			}
+			if value > 0 {
+				return 30000, true
+			}
+			return -30000, true
+		}
+	}
+	return 0, false
+}
+
+func scanLines(r io.Reader, out chan<- string) {
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		out <- strings.TrimSpace(scanner.Text())
+	}
+	close(out)
+}

--- a/cmd/analyze-match/main_test.go
+++ b/cmd/analyze-match/main_test.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseCentipawnScore(t *testing.T) {
+	score, ok := parseCentipawnScore("info depth 12 score cp -84 pv e2e4")
+	assert.True(t, ok)
+	assert.Equal(t, -84, score)
+}
+
+func TestParseMateScore(t *testing.T) {
+	score, ok := parseCentipawnScore("info depth 18 score mate 3 pv e2e4")
+	assert.True(t, ok)
+	assert.Equal(t, 30000, score)
+
+	score, ok = parseCentipawnScore("info depth 18 score mate -2 pv e7e5")
+	assert.True(t, ok)
+	assert.Equal(t, -30000, score)
+}

--- a/cmd/match/main.go
+++ b/cmd/match/main.go
@@ -19,6 +19,7 @@ func main() {
 	var moveOverheadMs int
 	var notes string
 	var plain bool
+	var recordPath string
 
 	flag.StringVar(&opponentTag, "opponent-tag", "", "Git tag to build and use as the opponent")
 	flag.IntVar(&games, "games", 2, "Number of games to play")
@@ -27,6 +28,7 @@ func main() {
 	flag.IntVar(&moveOverheadMs, "move-overhead", 50, "Milliseconds subtracted from movetime before sending go movetime to the engine")
 	flag.StringVar(&notes, "notes", "", "Optional notes to include in the printed markdown row")
 	flag.BoolVar(&plain, "plain", false, "Use plain line-based progress instead of the live terminal dashboard")
+	flag.StringVar(&recordPath, "record-path", "", "Optional JSONL path for per-move FEN/move records")
 	flag.Parse()
 
 	repoRoot, err := os.Getwd()
@@ -56,14 +58,15 @@ func main() {
 	}
 
 	summary, err := match.RunMatch(match.Config{
-		RepoRoot:    repoRoot,
-		OpponentTag: opponentTag,
-		Games:       games,
-		Parallelism: parallel,
-		MoveTime:    time.Duration(moveTimeMs) * time.Millisecond,
+		RepoRoot:     repoRoot,
+		OpponentTag:  opponentTag,
+		Games:        games,
+		Parallelism:  parallel,
+		MoveTime:     time.Duration(moveTimeMs) * time.Millisecond,
 		MoveOverhead: time.Duration(moveOverheadMs) * time.Millisecond,
-		Notes:       notes,
-		Progress:    progress,
+		Notes:        notes,
+		RecordPath:   recordPath,
+		Progress:     progress,
 	})
 	if err != nil {
 		panic(err)

--- a/internal/match/history.go
+++ b/internal/match/history.go
@@ -22,6 +22,18 @@ type Summary struct {
 	Notes         string
 }
 
+type MoveRecord struct {
+	GameIndex      int       `json:"game_index"`
+	Ply            int       `json:"ply"`
+	CurrentAsWhite bool      `json:"current_as_white"`
+	SideToMove     string    `json:"side_to_move"`
+	Player         string    `json:"player"`
+	Move           string    `json:"move"`
+	FENBefore      string    `json:"fen_before"`
+	FENAfter       string    `json:"fen_after"`
+	Timestamp      time.Time `json:"timestamp"`
+}
+
 type IllegalMoveDiagnostic struct {
 	GameIndex      int
 	CurrentAsWhite bool

--- a/internal/match/record_writer.go
+++ b/internal/match/record_writer.go
@@ -1,0 +1,50 @@
+package match
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+type RecordWriter struct {
+	mu   sync.Mutex
+	file *os.File
+	enc  *json.Encoder
+}
+
+func NewRecordWriter(path string) (*RecordWriter, error) {
+	if path == "" {
+		return nil, nil
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, err
+	}
+	file, err := os.Create(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return &RecordWriter{
+		file: file,
+		enc:  json.NewEncoder(file),
+	}, nil
+}
+
+func (w *RecordWriter) Write(record MoveRecord) error {
+	if w == nil {
+		return nil
+	}
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.enc.Encode(record)
+}
+
+func (w *RecordWriter) Close() error {
+	if w == nil {
+		return nil
+	}
+	return w.file.Close()
+}

--- a/internal/match/record_writer_test.go
+++ b/internal/match/record_writer_test.go
@@ -1,0 +1,45 @@
+package match
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRecordWriterWritesJSONL(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "records.jsonl")
+
+	writer, err := NewRecordWriter(path)
+	assert.NoError(t, err)
+	assert.NotNil(t, writer)
+
+	record := MoveRecord{
+		GameIndex:      1,
+		Ply:            2,
+		CurrentAsWhite: true,
+		SideToMove:     "black",
+		Player:         "current",
+		Move:           "e2e4",
+		FENBefore:      "before fen",
+		FENAfter:       "after fen",
+		Timestamp:      time.Date(2026, 4, 1, 19, 0, 0, 0, time.UTC),
+	}
+	assert.NoError(t, writer.Write(record))
+	assert.NoError(t, writer.Close())
+
+	data, err := os.ReadFile(path)
+	assert.NoError(t, err)
+
+	var decoded MoveRecord
+	assert.NoError(t, json.Unmarshal(data, &decoded))
+	assert.Equal(t, record.GameIndex, decoded.GameIndex)
+	assert.Equal(t, record.Ply, decoded.Ply)
+	assert.Equal(t, record.Move, decoded.Move)
+	assert.Equal(t, record.FENBefore, decoded.FENBefore)
+	assert.Equal(t, record.FENAfter, decoded.FENAfter)
+}

--- a/internal/match/runner.go
+++ b/internal/match/runner.go
@@ -27,6 +27,7 @@ type Config struct {
 	Notes         string
 	CurrentLabel  string
 	CurrentBinary string
+	RecordPath    string
 	Progress      func(Snapshot)
 }
 
@@ -131,6 +132,14 @@ func RunMatch(cfg Config) (Summary, error) {
 	state := newMatchState(cfg, opponent.Label)
 	state.emit()
 
+	recordWriter, err := NewRecordWriter(cfg.RecordPath)
+	if err != nil {
+		return Summary{}, err
+	}
+	if recordWriter != nil {
+		defer recordWriter.Close()
+	}
+
 	stopTicker := make(chan struct{})
 	var tickerWG sync.WaitGroup
 	if cfg.Progress != nil {
@@ -163,7 +172,7 @@ func RunMatch(cfg Config) (Summary, error) {
 		workers.Add(1)
 		go func() {
 			defer workers.Done()
-			if err := runWorker(currentBinary.Path, opponent.Path, cfg.MoveTime, jobs, results, state); err != nil {
+			if err := runWorker(currentBinary.Path, opponent.Path, cfg.MoveTime, jobs, results, state, recordWriter); err != nil {
 				select {
 				case errs <- err:
 				default:
@@ -201,7 +210,7 @@ func RunMatch(cfg Config) (Summary, error) {
 	return state.summary, nil
 }
 
-func runWorker(currentPath, opponentPath string, moveTime time.Duration, jobs <-chan int, results chan<- gameResult, state *matchState) error {
+func runWorker(currentPath, opponentPath string, moveTime time.Duration, jobs <-chan int, results chan<- gameResult, state *matchState, recordWriter *RecordWriter) error {
 	currentClient, err := NewUCIClient(currentPath)
 	if err != nil {
 		return err
@@ -231,6 +240,8 @@ func runWorker(currentPath, opponentPath string, moveTime time.Duration, jobs <-
 			opponentClient,
 			currentAsWhite,
 			effectiveMoveTime(moveTime, state.cfg.MoveOverhead),
+			gameIndex,
+			recordWriter,
 			func(ply int) {
 				state.updatePlies(gameIndex, ply)
 			},
@@ -403,7 +414,7 @@ func (s *matchState) emitLocked() {
 	})
 }
 
-func playSingleGame(currentClient, opponentClient *UCIClient, currentIsWhite bool, moveTime time.Duration, onPly func(int)) (int, int, string, uint64, time.Duration, *IllegalMoveDiagnostic, error) {
+func playSingleGame(currentClient, opponentClient *UCIClient, currentIsWhite bool, moveTime time.Duration, gameIndex int, recordWriter *RecordWriter, onPly func(int)) (int, int, string, uint64, time.Duration, *IllegalMoveDiagnostic, error) {
 	referee := engine.NewEngine()
 	pos, err := board.NewPositionFromFEN(board.FenStartPos)
 	if err != nil {
@@ -433,6 +444,7 @@ func playSingleGame(currentClient, opponentClient *UCIClient, currentIsWhite boo
 		}
 
 		client := selectClient(currentClient, opponentClient, pos.ActiveColor(), currentIsWhite)
+		fenBefore := pos.FEN()
 		bestMove, stats, err := client.BestMove(moves, moveTime)
 		if err != nil {
 			currentToMove := (pos.ActiveColor() == board.White) == currentIsWhite
@@ -460,6 +472,10 @@ func playSingleGame(currentClient, opponentClient *UCIClient, currentIsWhite boo
 			return 1, ply, "illegal move", totalNodes, totalSearchTime, diagnostic, nil
 		}
 
+		if err := writeMoveRecord(recordWriter, gameIndex, ply, currentIsWhite, fenBefore, bestMove, pos.FEN(), pos.ActiveColor()); err != nil {
+			return 0, ply, "", totalNodes, totalSearchTime, nil, err
+		}
+
 		moves = append(moves, bestMove)
 		repetitionCount[pos.ZobristKey()]++
 		if onPly != nil {
@@ -468,6 +484,35 @@ func playSingleGame(currentClient, opponentClient *UCIClient, currentIsWhite boo
 	}
 
 	return 0, defaultMaxPlies, "max plies", totalNodes, totalSearchTime, nil, nil
+}
+
+func writeMoveRecord(recordWriter *RecordWriter, gameIndex int, ply int, currentAsWhite bool, fenBefore, move, fenAfter string, nextToMove int8) error {
+	if recordWriter == nil {
+		return nil
+	}
+
+	sideToMove := "white"
+	if nextToMove == board.Black {
+		sideToMove = "black"
+	}
+
+	player := "opponent"
+	moveColorWasWhite := nextToMove == board.Black
+	if moveColorWasWhite == currentAsWhite {
+		player = "current"
+	}
+
+	return recordWriter.Write(MoveRecord{
+		GameIndex:      gameIndex + 1,
+		Ply:            ply + 1,
+		CurrentAsWhite: currentAsWhite,
+		SideToMove:     sideToMove,
+		Player:         player,
+		Move:           move,
+		FENBefore:      fenBefore,
+		FENAfter:       fenAfter,
+		Timestamp:      time.Now().UTC(),
+	})
 }
 
 func (s *matchState) updatePlies(gameIndex int, plies int) {

--- a/project.md
+++ b/project.md
@@ -106,6 +106,7 @@ Useful flags:
 - `-movetime <ms>`: per-move time budget in milliseconds
 - `-move-overhead <ms>`: safety margin subtracted before sending `go movetime`
 - `-notes "<text>"`: note included in the printed markdown row
+- `-record-path <path>`: optional JSONL move log with FEN before/after every move
 - `-plain`: line-based progress output instead of the live terminal dashboard
 
 Useful `make` variables:
@@ -117,6 +118,30 @@ Useful `make` variables:
 - `MOVETIME=<ms>`
 - `MOVE_OVERHEAD=<ms>`
 - `NOTES="<text>"`
+- `RECORD_PATH=<path>`
+
+## Analyze Match Blunders With Stockfish
+
+Record a match to JSONL:
+
+```bash
+make runner MODE=plain GAMES=2 MOVETIME=1000 OPPONENT_TAG=score-v1 RECORD_PATH=.codex-tmp/match/records.jsonl
+```
+
+Then analyze the largest evaluation swings with Stockfish:
+
+```bash
+make analyze-match RECORD_PATH=.codex-tmp/match/records.jsonl STOCKFISH=stockfish ANALYZE_MOVETIME=250 ANALYZE_LIMIT=20 ANALYZE_MIN_SWING=150
+```
+
+The analyzer prints the biggest centipawn drops for recorded moves, including:
+
+- game index
+- ply
+- move played
+- Stockfish best move on the pre-move position
+- centipawn score before and after the move
+- FEN before and after the move
 
 Output shape:
 


### PR DESCRIPTION
Closes #54

## Summary
- add optional per-move JSONL recording to the match runner with FEN before/after each move
- add `cmd/analyze-match` to replay those records through Stockfish and rank the biggest evaluation swings
- add tests for JSONL writing and Stockfish score parsing
- document and expose the workflow through `make runner` and `make analyze-match`

## Validation
- `GOCACHE=/home/fab/Projects/gochess/.codex-tmp/go-build-cache go test ./cmd/analyze-match ./internal/match`
- `GOCACHE=/home/fab/Projects/gochess/.codex-tmp/go-build-cache go test ./...`
- smoke tested `cmd/analyze-match` loading a synthetic JSONL sample