### PR TITLE
Penalize overextended heavy pieces

### DIFF
--- a/internal/eval/evaluator.go
+++ b/internal/eval/evaluator.go
@@ -70,6 +70,8 @@ const (
 	isolatedPawnPenaltyEG  Score = 7
 	doubledPawnPenaltyMG   Score = 10
 	doubledPawnPenaltyEG   Score = 8
+	queenOverextensionBase Score = 18
+	rookOverextensionBase  Score = 12
 )
 
 const kingSafetyTradeValue Score = 2000
@@ -400,10 +402,46 @@ func pieceSafetyScore(pos *board.Position, color int8) Score {
 			}
 		}
 
+		penalty += heavyPieceOverextensionPenalty(piece, idx, color, attackers, defenders, leastAttacker, leastDefender)
 		score -= penalty
 	}
 
 	return score
+}
+
+func heavyPieceOverextensionPenalty(piece board.Piece, idx, color int8, attackers, defenders int, leastAttacker, leastDefender Score) Score {
+	if piece.Type() != board.Queen && piece.Type() != board.Rook {
+		return DrawScore
+	}
+	if !isEnemyTerritorySquare(color, idx) || attackers == 0 {
+		return DrawScore
+	}
+
+	basePenalty := rookOverextensionBase
+	if piece.Type() == board.Queen {
+		basePenalty = queenOverextensionBase
+	}
+
+	depth := enemyTerritoryDepth(color, idx)
+	penalty := basePenalty + Score(attackers)*basePenalty/2 + Score(depth)*basePenalty/3
+
+	switch {
+	case defenders == 0:
+		penalty += basePenalty
+	case attackers >= defenders:
+		penalty += basePenalty / 2
+	}
+
+	if leastAttacker > 0 {
+		if leastAttacker < tradeSafetyValue(piece.Type()) {
+			penalty += basePenalty
+		}
+		if leastDefender == 0 || leastDefender > leastAttacker {
+			penalty += basePenalty / 2
+		}
+	}
+
+	return penalty
 }
 
 func kingSafetyPenalty(pos *board.Position, color int8, phase int) Score {
@@ -576,6 +614,22 @@ func tradeSafetyValue(pieceType int8) Score {
 		return kingSafetyTradeValue
 	}
 	return pieceValues[pieceType]
+}
+
+func isEnemyTerritorySquare(color, idx int8) bool {
+	rank := board.RankFromIdx(idx)
+	if color == board.White {
+		return rank >= 4
+	}
+	return rank <= 3
+}
+
+func enemyTerritoryDepth(color, idx int8) int8 {
+	rank := board.RankFromIdx(idx)
+	if color == board.White {
+		return rank - 3
+	}
+	return 4 - rank
 }
 
 func pawnShieldPenalty(pos *board.Position, color, kingIdx int8, phase int) Score {

--- a/internal/eval/evaluator_test.go
+++ b/internal/eval/evaluator_test.go
@@ -137,6 +137,24 @@ func TestStaticEvaluatorEvaluate(t *testing.T) {
 				assert.Greater(t, healthy, weak)
 			},
 		},
+		"overextended queen in enemy territory is penalized against a safe queen": {
+			fen: "4k3/3Q4/8/8/6b1/8/8/4K3 w - - 0 1",
+			assertion: func(t *testing.T, exposed Score) {
+				safePos, err := board.NewPositionFromFEN("4k3/8/8/8/6b1/3Q4/8/4K3 w - - 0 1")
+				assert.NoError(t, err)
+				safe := evaluator.Evaluate(safePos)
+				assert.Less(t, exposed, safe)
+			},
+		},
+		"overextended rook in enemy territory is penalized against a safe rook": {
+			fen: "4k3/1R6/8/8/8/8/6b1/4K3 w - - 0 1",
+			assertion: func(t *testing.T, exposed Score) {
+				safePos, err := board.NewPositionFromFEN("4k3/8/8/8/8/1R6/6b1/4K3 w - - 0 1")
+				assert.NoError(t, err)
+				safe := evaluator.Evaluate(safePos)
+				assert.Less(t, exposed, safe)
+			},
+		},
 	}
 
 	for name, tt := range tests {


### PR DESCRIPTION
## Summary
- add a targeted piece-safety penalty for queens and rooks that push into enemy territory on contested squares
- scale the malus by depth, support, and cheap enemy recaptures so sound invasions are penalized less than toxic ones
- add queen/rook regression tests for the recurring Stockfish swing pattern

Closes #62