### PR TITLE
Penalize unsafe heavy-piece raids

### DIFF
--- a/internal/eval/evaluator.go
+++ b/internal/eval/evaluator.go
@@ -72,6 +72,8 @@ const (
 	doubledPawnPenaltyEG   Score = 8
 	queenOverextensionBase Score = 18
 	rookOverextensionBase  Score = 12
+	queenRaidPenaltyBase   Score = 28
+	rookRaidPenaltyBase    Score = 20
 )
 
 const kingSafetyTradeValue Score = 2000
@@ -402,14 +404,14 @@ func pieceSafetyScore(pos *board.Position, color int8) Score {
 			}
 		}
 
-		penalty += heavyPieceOverextensionPenalty(piece, idx, color, attackers, defenders, leastAttacker, leastDefender)
+		penalty += heavyPieceOverextensionPenalty(pos, piece, idx, color, attackers, defenders, leastAttacker, leastDefender)
 		score -= penalty
 	}
 
 	return score
 }
 
-func heavyPieceOverextensionPenalty(piece board.Piece, idx, color int8, attackers, defenders int, leastAttacker, leastDefender Score) Score {
+func heavyPieceOverextensionPenalty(pos *board.Position, piece board.Piece, idx, color int8, attackers, defenders int, leastAttacker, leastDefender Score) Score {
 	if piece.Type() != board.Queen && piece.Type() != board.Rook {
 		return DrawScore
 	}
@@ -439,6 +441,34 @@ func heavyPieceOverextensionPenalty(piece board.Piece, idx, color int8, attacker
 		if leastDefender == 0 || leastDefender > leastAttacker {
 			penalty += basePenalty / 2
 		}
+	}
+
+	penalty += unsafeHeavyRaidPenalty(pos, piece, idx, color, attackers, defenders)
+	return penalty
+}
+
+func unsafeHeavyRaidPenalty(pos *board.Position, piece board.Piece, idx, color int8, attackers, defenders int) Score {
+	depth := enemyTerritoryDepth(color, idx)
+	if depth < 2 {
+		return DrawScore
+	}
+
+	basePenalty := rookRaidPenaltyBase
+	if piece.Type() == board.Queen {
+		basePenalty = queenRaidPenaltyBase
+	}
+
+	safeRetreats := safeHeavyRetreatCount(pos, piece, idx, color)
+	if safeRetreats >= 3 {
+		return DrawScore
+	}
+
+	penalty := basePenalty * Score(3-safeRetreats)
+	if attackers > defenders {
+		penalty += basePenalty / 2
+	}
+	if safeRetreats == 0 {
+		penalty += basePenalty / 2
 	}
 
 	return penalty
@@ -630,6 +660,46 @@ func enemyTerritoryDepth(color, idx int8) int8 {
 		return rank - 3
 	}
 	return 4 - rank
+}
+
+func safeHeavyRetreatCount(pos *board.Position, piece board.Piece, idx, color int8) int {
+	enemyColor := board.White
+	if color == board.White {
+		enemyColor = board.Black
+	}
+
+	currentDepth := enemyTerritoryDepth(color, idx)
+	targets := movegen.PseudoLegalTargetsMask(pos, piece, idx)
+	count := 0
+
+	for targets != 0 {
+		target := int8(bits.TrailingZeros64(targets))
+		targets &^= 1 << target
+
+		if retreatDepth(color, target) > currentDepth {
+			continue
+		}
+
+		enemyAttackers := attackCountOnSquare(pos, enemyColor, target)
+		friendlyDefenders := attackCountOnSquare(pos, color, target)
+		if movegen.PieceAttackMask(pos, piece, idx)&(uint64(1)<<target) != 0 && friendlyDefenders > 0 {
+			friendlyDefenders--
+		}
+		leastEnemy := leastAttackerValueOnSquare(pos, enemyColor, target)
+
+		if enemyAttackers == 0 || friendlyDefenders > enemyAttackers || leastEnemy >= tradeSafetyValue(piece.Type()) {
+			count++
+		}
+	}
+
+	return count
+}
+
+func retreatDepth(color, idx int8) int8 {
+	if !isEnemyTerritorySquare(color, idx) {
+		return 0
+	}
+	return enemyTerritoryDepth(color, idx)
 }
 
 func pawnShieldPenalty(pos *board.Position, color, kingIdx int8, phase int) Score {

--- a/internal/eval/evaluator_test.go
+++ b/internal/eval/evaluator_test.go
@@ -155,6 +155,24 @@ func TestStaticEvaluatorEvaluate(t *testing.T) {
 				assert.Less(t, exposed, safe)
 			},
 		},
+		"deep rook raid with fewer escape squares scores worse than a shallower rook": {
+			fen: "1r4k1/pR6/8/8/8/8/6b1/4K3 w - - 0 1",
+			assertion: func(t *testing.T, trapped Score) {
+				saferPos, err := board.NewPositionFromFEN("1r4k1/p7/3R4/8/8/8/6b1/4K3 w - - 0 1")
+				assert.NoError(t, err)
+				safer := evaluator.Evaluate(saferPos)
+				assert.Less(t, trapped, safer)
+			},
+		},
+		"deep queen raid with fewer escape squares scores worse than a shallower queen": {
+			fen: "6k1/6pp/8/8/8/7b/6Q1/4K3 w - - 0 1",
+			assertion: func(t *testing.T, trapped Score) {
+				saferPos, err := board.NewPositionFromFEN("6k1/6pp/8/8/6Q1/7b/8/4K3 w - - 0 1")
+				assert.NoError(t, err)
+				safer := evaluator.Evaluate(saferPos)
+				assert.Less(t, trapped, safer)
+			},
+		},
 	}
 
 	for name, tt := range tests {


### PR DESCRIPTION
## Summary
- extend heavy-piece safety scoring with an explicit unsafe raid penalty for deep queen/rook incursions
- estimate whether the raiding piece has any safe retreat squares instead of only checking the landing square
- add regression tests for trapped rook and queen raids that mirror the Stockfish swing pattern

Closes #64